### PR TITLE
remove subsidy from AMMWrapper

### DIFF
--- a/contracts/AMMWrapper.sol
+++ b/contracts/AMMWrapper.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity 0.7.6;
 pragma abicoder v2;
 

--- a/contracts/AMMWrapper.sol
+++ b/contracts/AMMWrapper.sol
@@ -1,4 +1,5 @@
 pragma solidity 0.7.6;
+pragma abicoder v2;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
@@ -12,30 +13,30 @@ import "./interfaces/IWeth.sol";
 import "./interfaces/IPermanentStorage.sol";
 import "./utils/AMMLibEIP712.sol";
 import "./utils/BaseLibEIP712.sol";
+import "./utils/LibConstant.sol";
 import "./utils/SignatureValidator.sol";
 
 contract AMMWrapper is IAMMWrapper, ReentrancyGuard, BaseLibEIP712, SignatureValidator {
+    using SafeMath for uint16;
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
 
     // Constants do not have storage slot.
     string public constant version = "5.2.0";
-    uint256 internal constant MAX_UINT = 2**256 - 1;
-    uint256 internal constant BPS_MAX = 10000;
     address internal constant ETH_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
     address internal constant ZERO_ADDRESS = address(0);
     address public immutable userProxy;
     IWETH public immutable weth;
     IPermanentStorage public immutable permStorage;
-    address public constant UNISWAP_V2_ROUTER_02_ADDRESS = 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D;
-    address public constant SUSHISWAP_ROUTER_ADDRESS = 0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F;
+    address public immutable UNISWAP_V2_ROUTER_02_ADDRESS;
+    address public immutable SUSHISWAP_ROUTER_ADDRESS;
 
     // Below are the variables which consume storage slots.
     address public operator;
-    uint256 public subsidyFactor;
+    uint16 public feeFactor;
     ISpender public spender;
 
-    /* Struct and event declaration */
+    /* Struct declaration */
     // Group the local variables together to prevent
     // Compiler error: Stack too deep, try removing local variables.
     struct TxMetaData {
@@ -43,8 +44,6 @@ contract AMMWrapper is IAMMWrapper, ReentrancyGuard, BaseLibEIP712, SignatureVal
         bytes32 transactionHash;
         uint256 settleAmount;
         uint256 receivedAmount;
-        uint16 feeFactor;
-        uint16 subsidyFactor;
     }
 
     struct InternalTxData {
@@ -61,30 +60,6 @@ contract AMMWrapper is IAMMWrapper, ReentrancyGuard, BaseLibEIP712, SignatureVal
         int128 toTokenCurveIndex;
         uint16 swapMethod;
     }
-
-    // Operator events
-    event TransferOwnership(address newOperator);
-    event UpgradeSpender(address newSpender);
-    event SetSubsidyFactor(uint256 newSubisdyFactor);
-    event AllowTransfer(address spender);
-    event DisallowTransfer(address spender);
-    event DepositETH(uint256 ethBalance);
-
-    event Swapped(
-        string source,
-        bytes32 indexed transactionHash,
-        address indexed userAddr,
-        address takerAssetAddr,
-        uint256 takerAssetAmount,
-        address makerAddr,
-        address makerAssetAddr,
-        uint256 makerAssetAmount,
-        address receiverAddr,
-        uint256 settleAmount,
-        uint256 receivedAmount,
-        uint16 feeFactor,
-        uint16 subsidyFactor
-    );
 
     receive() external payable {}
 
@@ -129,18 +104,22 @@ contract AMMWrapper is IAMMWrapper, ReentrancyGuard, BaseLibEIP712, SignatureVal
      *************************************************************/
     constructor(
         address _operator,
-        uint256 _subsidyFactor,
+        uint16 _feeFactor,
         address _userProxy,
         ISpender _spender,
         IPermanentStorage _permStorage,
-        IWETH _weth
+        IWETH _weth,
+        address _uniswapV2Router,
+        address _sushiswapRouter
     ) {
         operator = _operator;
-        subsidyFactor = _subsidyFactor;
+        feeFactor = _feeFactor;
         userProxy = _userProxy;
         spender = _spender;
         permStorage = _permStorage;
         weth = _weth;
+        UNISWAP_V2_ROUTER_02_ADDRESS = _uniswapV2Router;
+        SUSHISWAP_ROUTER_ADDRESS = _sushiswapRouter;
     }
 
     /************************************************************
@@ -156,18 +135,12 @@ contract AMMWrapper is IAMMWrapper, ReentrancyGuard, BaseLibEIP712, SignatureVal
         emit UpgradeSpender(_newSpender);
     }
 
-    function setSubsidyFactor(uint256 _subsidyFactor) external onlyOperator {
-        subsidyFactor = _subsidyFactor;
-
-        emit SetSubsidyFactor(_subsidyFactor);
-    }
-
     /**
      * @dev approve spender to transfer tokens from this contract. This is used to collect fee.
      */
     function setAllowance(address[] calldata _tokenList, address _spender) external override onlyOperator {
         for (uint256 i = 0; i < _tokenList.length; i++) {
-            IERC20(_tokenList[i]).safeApprove(_spender, MAX_UINT);
+            IERC20(_tokenList[i]).safeApprove(_spender, LibConstant.MAX_UINT);
 
             emit AllowTransfer(_spender);
         }
@@ -179,6 +152,12 @@ contract AMMWrapper is IAMMWrapper, ReentrancyGuard, BaseLibEIP712, SignatureVal
 
             emit DisallowTransfer(_spender);
         }
+    }
+
+    function setFeeFactor(uint16 _feeFactor) external onlyOperator {
+        feeFactor = _feeFactor;
+
+        emit SetFeeFactor(_feeFactor);
     }
 
     /**
@@ -196,82 +175,36 @@ contract AMMWrapper is IAMMWrapper, ReentrancyGuard, BaseLibEIP712, SignatureVal
     /************************************************************
      *                   External functions                      *
      *************************************************************/
-    function trade(
-        address _makerAddr,
-        address _takerAssetAddr,
-        address _makerAssetAddr,
-        uint256 _takerAssetAmount,
-        uint256 _makerAssetAmount,
-        uint256 _feeFactor,
-        address _userAddr,
-        address payable _receiverAddr,
-        uint256 _salt,
-        uint256 _deadline,
-        bytes calldata _sig
-    ) external payable override nonReentrant onlyUserProxy returns (uint256) {
-        AMMLibEIP712.Order memory order = AMMLibEIP712.Order(
-            _makerAddr,
-            _takerAssetAddr,
-            _makerAssetAddr,
-            _takerAssetAmount,
-            _makerAssetAmount,
-            _userAddr,
-            _receiverAddr,
-            _salt,
-            _deadline
-        );
-        require(order.deadline >= block.timestamp, "AMMWrapper: expired order");
+    function trade(AMMLibEIP712.Order calldata _order, bytes calldata _sig) external payable override nonReentrant onlyUserProxy returns (uint256) {
+        require(_order.deadline >= block.timestamp, "AMMWrapper: expired order");
         TxMetaData memory txMetaData;
         InternalTxData memory internalTxData;
 
-        // These variables are copied straight from function parameters and
-        // used to bypass stack too deep error.
-        txMetaData.subsidyFactor = uint16(subsidyFactor);
-        txMetaData.feeFactor = uint16(_feeFactor);
-        if (!permStorage.isRelayerValid(tx.origin)) {
-            txMetaData.feeFactor = (txMetaData.subsidyFactor > txMetaData.feeFactor) ? txMetaData.subsidyFactor : txMetaData.feeFactor;
-            txMetaData.subsidyFactor = 0;
-        }
-
         // Assign trade vairables
-        internalTxData.fromEth = (order.takerAssetAddr == ZERO_ADDRESS || order.takerAssetAddr == ETH_ADDRESS);
-        internalTxData.toEth = (order.makerAssetAddr == ZERO_ADDRESS || order.makerAssetAddr == ETH_ADDRESS);
-        if (_isCurve(order.makerAddr)) {
+        internalTxData.fromEth = (_order.takerAssetAddr == ZERO_ADDRESS || _order.takerAssetAddr == ETH_ADDRESS);
+        internalTxData.toEth = (_order.makerAssetAddr == ZERO_ADDRESS || _order.makerAssetAddr == ETH_ADDRESS);
+        if (_isCurve(_order.makerAddr)) {
             // PermanetStorage can recognize `ETH_ADDRESS` but not `ZERO_ADDRESS`.
-            // Convert it to `ETH_ADDRESS` as passed in `order.takerAssetAddr` or `order.makerAssetAddr` might be `ZERO_ADDRESS`.
-            internalTxData.takerAssetInternalAddr = internalTxData.fromEth ? ETH_ADDRESS : order.takerAssetAddr;
-            internalTxData.makerAssetInternalAddr = internalTxData.toEth ? ETH_ADDRESS : order.makerAssetAddr;
+            // Convert it to `ETH_ADDRESS` as passed in `_order.takerAssetAddr` or `_order.makerAssetAddr` might be `ZERO_ADDRESS`.
+            internalTxData.takerAssetInternalAddr = internalTxData.fromEth ? ETH_ADDRESS : _order.takerAssetAddr;
+            internalTxData.makerAssetInternalAddr = internalTxData.toEth ? ETH_ADDRESS : _order.makerAssetAddr;
         } else {
-            internalTxData.takerAssetInternalAddr = internalTxData.fromEth ? address(weth) : order.takerAssetAddr;
-            internalTxData.makerAssetInternalAddr = internalTxData.toEth ? address(weth) : order.makerAssetAddr;
+            internalTxData.takerAssetInternalAddr = internalTxData.fromEth ? address(weth) : _order.takerAssetAddr;
+            internalTxData.makerAssetInternalAddr = internalTxData.toEth ? address(weth) : _order.makerAssetAddr;
         }
 
-        txMetaData.transactionHash = _verify(order, _sig);
+        txMetaData.transactionHash = _verify(_order, _sig);
 
-        _prepare(order, internalTxData);
+        _prepare(_order, internalTxData);
 
-        // minAmount = makerAssetAmount * (10000 - subsidyFactor) / 10000
-        uint256 _minAmount = order.makerAssetAmount.mul((BPS_MAX.sub(txMetaData.subsidyFactor))).div(BPS_MAX);
-        (txMetaData.source, txMetaData.receivedAmount) = _swap(order, internalTxData, _minAmount);
+        // amountOutMin = makerAssetAmount * (10000 + feeFactor) / 10000
+        uint256 _amountOutMin = _order.makerAssetAmount.mul((LibConstant.BPS_MAX.add(feeFactor))).div(LibConstant.BPS_MAX);
+        (txMetaData.source, txMetaData.receivedAmount) = _swap(_order, internalTxData, _amountOutMin);
 
         // Settle
-        txMetaData.settleAmount = _settle(order, txMetaData, internalTxData);
+        txMetaData.settleAmount = _settle(_order, txMetaData, internalTxData);
 
-        emit Swapped(
-            txMetaData.source,
-            txMetaData.transactionHash,
-            order.userAddr,
-            order.takerAssetAddr,
-            order.takerAssetAmount,
-            order.makerAddr,
-            order.makerAssetAddr,
-            order.makerAssetAmount,
-            order.receiverAddr,
-            txMetaData.settleAmount,
-            txMetaData.receivedAmount,
-            txMetaData.feeFactor,
-            txMetaData.subsidyFactor
-        );
+        emitSwappedEvent(_order, txMetaData);
 
         return txMetaData.settleAmount;
     }
@@ -280,7 +213,7 @@ contract AMMWrapper is IAMMWrapper, ReentrancyGuard, BaseLibEIP712, SignatureVal
      * @dev internal function of `trade`.
      * Used to tell if maker is Curve.
      */
-    function _isCurve(address _makerAddr) internal pure virtual returns (bool) {
+    function _isCurve(address _makerAddr) internal view virtual returns (bool) {
         if (_makerAddr == UNISWAP_V2_ROUTER_02_ADDRESS || _makerAddr == SUSHISWAP_ROUTER_ADDRESS) return false;
         else return true;
     }
@@ -345,7 +278,7 @@ contract AMMWrapper is IAMMWrapper, ReentrancyGuard, BaseLibEIP712, SignatureVal
     function _swap(
         AMMLibEIP712.Order memory _order,
         InternalTxData memory _internalTxData,
-        uint256 _minAmount
+        uint256 _amountOutMin
     )
         internal
         approveTakerAsset(_internalTxData.takerAssetInternalAddr, _order.makerAddr, _order.takerAssetAmount)
@@ -359,7 +292,7 @@ contract AMMWrapper is IAMMWrapper, ReentrancyGuard, BaseLibEIP712, SignatureVal
                 _internalTxData.takerAssetInternalAddr,
                 _internalTxData.makerAssetInternalAddr,
                 _order.takerAssetAmount,
-                _minAmount,
+                _amountOutMin,
                 _order.deadline
             );
         } else {
@@ -383,7 +316,7 @@ contract AMMWrapper is IAMMWrapper, ReentrancyGuard, BaseLibEIP712, SignatureVal
                     curveData.fromTokenCurveIndex,
                     curveData.toTokenCurveIndex,
                     _order.takerAssetAmount,
-                    _minAmount,
+                    _amountOutMin,
                     curveData.swapMethod
                 );
                 uint256 balanceAfterTrade = _getSelfBalance(_internalTxData.makerAssetInternalAddr);
@@ -403,48 +336,9 @@ contract AMMWrapper is IAMMWrapper, ReentrancyGuard, BaseLibEIP712, SignatureVal
         TxMetaData memory _txMetaData,
         InternalTxData memory _internalTxData
     ) internal returns (uint256 settleAmount) {
-        // Convert var type from uint16 to uint256
-        uint256 _feeFactor = _txMetaData.feeFactor;
-        uint256 _subsidyFactor = _txMetaData.subsidyFactor;
-
-        if (_txMetaData.receivedAmount == _order.makerAssetAmount) {
-            settleAmount = _txMetaData.receivedAmount;
-        } else if (_txMetaData.receivedAmount > _order.makerAssetAmount) {
-            // shouldCollectFee = ((receivedAmount - makerAssetAmount) / receivedAmount) > (feeFactor / 10000)
-            bool shouldCollectFee = _txMetaData.receivedAmount.sub(_order.makerAssetAmount).mul(BPS_MAX) > _feeFactor.mul(_txMetaData.receivedAmount);
-            if (shouldCollectFee) {
-                // settleAmount = receivedAmount * (1 - feeFactor) / 10000
-                settleAmount = _txMetaData.receivedAmount.mul(BPS_MAX.sub(_feeFactor)).div(BPS_MAX);
-            } else {
-                settleAmount = _order.makerAssetAmount;
-            }
-        } else {
-            require(_subsidyFactor > 0, "AMMWrapper: this trade will not be subsidized");
-
-            // If fee factor is smaller than subsidy factor, choose fee factor as actual subsidy factor
-            // since we should subsidize less if we charge less.
-            uint256 actualSubsidyFactor = (_subsidyFactor < _feeFactor) ? _subsidyFactor : _feeFactor;
-
-            // inSubsidyRange = ((makerAssetAmount - receivedAmount) / receivedAmount) > (actualSubsidyFactor / 10000)
-            bool inSubsidyRange = _order.makerAssetAmount.sub(_txMetaData.receivedAmount).mul(BPS_MAX) <= actualSubsidyFactor.mul(_txMetaData.receivedAmount);
-            require(inSubsidyRange, "AMMWrapper: amount difference larger than subsidy amount");
-
-            uint256 selfBalance = _getSelfBalance(_internalTxData.makerAssetInternalAddr);
-            bool hasEnoughToSubsidize = selfBalance >= _order.makerAssetAmount;
-            if (!hasEnoughToSubsidize && _isInternalAssetETH(_internalTxData.makerAssetInternalAddr)) {
-                // We treat ETH and WETH the same so we have to convert WETH to ETH if ETH balance is not enough.
-                uint256 amountShort = _order.makerAssetAmount.sub(selfBalance);
-                if (amountShort <= weth.balanceOf(address(this))) {
-                    // Withdraw the amount short from WETH
-                    weth.withdraw(amountShort);
-                    // Now we have enough
-                    hasEnoughToSubsidize = true;
-                }
-            }
-            require(hasEnoughToSubsidize, "AMMWrapper: not enough savings to subsidize");
-
-            settleAmount = _order.makerAssetAmount;
-        }
+        // settleAmount = receivedAmount - fee
+        uint256 fee = _order.makerAssetAmount.mul(feeFactor).div(LibConstant.BPS_MAX);
+        settleAmount = _txMetaData.receivedAmount.sub(fee);
 
         // Transfer token/ETH to receiver
         if (_internalTxData.toEth) {
@@ -489,5 +383,22 @@ contract AMMWrapper is IAMMWrapper, ReentrancyGuard, BaseLibEIP712, SignatureVal
         path[1] = _makerAssetAddr;
         uint256[] memory amounts = router.swapExactTokensForTokens(_takerAssetAmount, _makerAssetAmount, path, address(this), _deadline);
         return amounts[1];
+    }
+
+    function emitSwappedEvent(AMMLibEIP712.Order memory _order, TxMetaData memory _txMetaData) internal {
+        emit Swapped(
+            _txMetaData.source,
+            _txMetaData.transactionHash,
+            _order.userAddr,
+            _order.takerAssetAddr,
+            _order.takerAssetAmount,
+            _order.makerAddr,
+            _order.makerAssetAddr,
+            _order.makerAssetAmount,
+            _order.receiverAddr,
+            _txMetaData.settleAmount,
+            _txMetaData.receivedAmount,
+            feeFactor
+        );
     }
 }

--- a/contracts/AMMWrapper.sol
+++ b/contracts/AMMWrapper.sol
@@ -155,6 +155,7 @@ contract AMMWrapper is IAMMWrapper, ReentrancyGuard, BaseLibEIP712, SignatureVal
     }
 
     function setDefaultFeeFactor(uint16 _defaultFeeFactor) external onlyOperator {
+        require(_defaultFeeFactor <= LibConstant.BPS_MAX, "AMMWrapper: invalid fee factor");
         defaultFeeFactor = _defaultFeeFactor;
 
         emit SetDefaultFeeFactor(_defaultFeeFactor);

--- a/contracts/AMMWrapperWithPath.sol
+++ b/contracts/AMMWrapperWithPath.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity 0.7.6;
 pragma abicoder v2;
 

--- a/contracts/interfaces/IAMMWrapper.sol
+++ b/contracts/interfaces/IAMMWrapper.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0;
 pragma abicoder v2;
 

--- a/contracts/interfaces/IAMMWrapper.sol
+++ b/contracts/interfaces/IAMMWrapper.sol
@@ -1,19 +1,31 @@
 pragma solidity >=0.7.0;
+pragma abicoder v2;
 
 import "./ISetAllowance.sol";
+import "../utils/AMMLibEIP712.sol";
 
 interface IAMMWrapper is ISetAllowance {
-    function trade(
-        address _makerAddress,
-        address _fromAssetAddress,
-        address _toAssetAddress,
-        uint256 _takerAssetAmount,
-        uint256 _makerAssetAmount,
-        uint256 _feeFactor,
-        address _spender,
-        address payable _receiver,
-        uint256 _nonce,
-        uint256 _deadline,
-        bytes memory _sig
-    ) external payable returns (uint256);
+    event TransferOwnership(address newOperator);
+    event UpgradeSpender(address newSpender);
+    event AllowTransfer(address spender);
+    event DisallowTransfer(address spender);
+    event DepositETH(uint256 ethBalance);
+    event SetFeeFactor(uint256 newFeeFactor);
+
+    event Swapped(
+        string source,
+        bytes32 indexed transactionHash,
+        address indexed userAddr,
+        address takerAssetAddr,
+        uint256 takerAssetAmount,
+        address makerAddr,
+        address makerAssetAddr,
+        uint256 makerAssetAmount,
+        address receiverAddr,
+        uint256 settleAmount,
+        uint256 receivedAmount,
+        uint16 feeFactor
+    );
+
+    function trade(AMMLibEIP712.Order calldata _order, bytes memory _sig) external payable returns (uint256);
 }

--- a/contracts/interfaces/IAMMWrapper.sol
+++ b/contracts/interfaces/IAMMWrapper.sol
@@ -10,7 +10,7 @@ interface IAMMWrapper is ISetAllowance {
     event AllowTransfer(address spender);
     event DisallowTransfer(address spender);
     event DepositETH(uint256 ethBalance);
-    event SetFeeFactor(uint256 newFeeFactor);
+    event SetDefaultFeeFactor(uint256 newDefaultFeeFactor);
 
     event Swapped(
         string source,
@@ -24,8 +24,15 @@ interface IAMMWrapper is ISetAllowance {
         address receiverAddr,
         uint256 settleAmount,
         uint256 receivedAmount,
-        uint16 feeFactor
+        uint16 feeFactor,
+        bool relayed
     );
 
     function trade(AMMLibEIP712.Order calldata _order, bytes memory _sig) external payable returns (uint256);
+
+    function tradeByRelayer(
+        AMMLibEIP712.Order calldata _order,
+        bytes memory _sig,
+        uint16 _feeFactor
+    ) external payable returns (uint256);
 }

--- a/contracts/interfaces/IAMMWrapper.sol
+++ b/contracts/interfaces/IAMMWrapper.sol
@@ -28,9 +28,7 @@ interface IAMMWrapper is ISetAllowance {
         bool relayed
     );
 
-    function trade(AMMLibEIP712.Order calldata _order, bytes memory _sig) external payable returns (uint256);
-
-    function tradeByRelayer(
+    function trade(
         AMMLibEIP712.Order calldata _order,
         bytes memory _sig,
         uint16 _feeFactor

--- a/contracts/interfaces/IAMMWrapperWithPath.sol
+++ b/contracts/interfaces/IAMMWrapperWithPath.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0;
 pragma abicoder v2;
 

--- a/contracts/interfaces/IAMMWrapperWithPath.sol
+++ b/contracts/interfaces/IAMMWrapperWithPath.sol
@@ -1,0 +1,22 @@
+pragma solidity >=0.7.0;
+pragma abicoder v2;
+
+import "./IAMMWrapper.sol";
+import "../utils/AMMLibEIP712.sol";
+
+interface IAMMWrapperWithPath is IAMMWrapper {
+    function trade(
+        AMMLibEIP712.Order calldata _order,
+        bytes calldata _sig,
+        bytes calldata _makerSpecificData,
+        address[] calldata _path
+    ) external payable returns (uint256);
+
+    function tradeByRelayer(
+        AMMLibEIP712.Order calldata _order,
+        bytes calldata _sig,
+        bytes calldata _makerSpecificData,
+        address[] calldata _path,
+        uint16 _feeFactor
+    ) external payable returns (uint256);
+}

--- a/contracts/interfaces/IAMMWrapperWithPath.sol
+++ b/contracts/interfaces/IAMMWrapperWithPath.sol
@@ -9,13 +9,6 @@ interface IAMMWrapperWithPath is IAMMWrapper {
         AMMLibEIP712.Order calldata _order,
         bytes calldata _sig,
         bytes calldata _makerSpecificData,
-        address[] calldata _path
-    ) external payable returns (uint256);
-
-    function tradeByRelayer(
-        AMMLibEIP712.Order calldata _order,
-        bytes calldata _sig,
-        bytes calldata _makerSpecificData,
         address[] calldata _path,
         uint16 _feeFactor
     ) external payable returns (uint256);


### PR DESCRIPTION
Remove AMMWrapping subsidy design and refactor fee logic. Allow feeFactor to be set by relayer in relayed case. Overwrite feeFactor using default one in general user case.