### PR TITLE
Adjust init function for new network

### DIFF
--- a/contracts/PermanentStorage.sol
+++ b/contracts/PermanentStorage.sol
@@ -86,9 +86,12 @@ contract PermanentStorage is IPermanentStorage {
      *              Constructor and init functions               *
      *************************************************************/
     /// @dev Replacing constructor and initialize the contract. This function should only be called once.
-    function initialize() external {
-        require(keccak256(abi.encodePacked(version)) == keccak256(abi.encodePacked("5.2.0")), "PermanentStorage: not upgrading from 5.2.0 version");
-        // upgrade from 5.2.0 to 5.3.0
+    function initialize(address _operator) external {
+        require(keccak256(abi.encodePacked(version)) == keccak256(abi.encodePacked("")), "PermanentStorage: not upgrading from empty");
+        require(_operator != address(0), "PermanentStorage: operator can not be zero address");
+        operator = _operator;
+
+        // Upgrade version
         version = "5.3.0";
     }
 

--- a/contracts/UserProxy.sol
+++ b/contracts/UserProxy.sol
@@ -44,13 +44,10 @@ contract UserProxy {
      *              Constructor and init functions               *
      *************************************************************/
     /// @dev Replacing constructor and initialize the contract. This function should only be called once.
-    function initialize(address _limitOrderAddr) external {
-        require(_limitOrderAddr != address(0), "UserProxy: _limitOrderAddr should not be 0");
-        require(keccak256(abi.encodePacked(version)) == keccak256(abi.encodePacked("5.2.0")), "UserProxy: not upgrading from version 5.2.0");
-
-        // Set Limit Order
-        LimitOrderStorage.getStorage().limitOrderAddr = _limitOrderAddr;
-        LimitOrderStorage.getStorage().isEnabled = true;
+    function initialize(address _operator) external {
+        require(keccak256(abi.encodePacked(version)) == keccak256(abi.encodePacked("")), "UserProxy: not upgrading from empty");
+        require(_operator != address(0), "UserProxy: operator can not be zero address");
+        operator = _operator;
 
         // Upgrade version
         version = "5.3.0";

--- a/contracts/test/PermanentStorage.t.sol
+++ b/contracts/test/PermanentStorage.t.sol
@@ -37,21 +37,8 @@ contract PermanentStorageTest is Test {
         // Deploy
         permanentStorage = new PermanentStorage();
         strategy = address(new MockStrategy());
-        // Setup
         // Set this contract as operator
-        // prettier-ignore
-        vm.store(
-            address(permanentStorage), // address
-            bytes32(uint256(0)), // key
-            bytes32(uint256(address(this))) // value
-        );
-        // Set version
-        // prettier-ignore
-        vm.store(
-            address(permanentStorage), // address
-            bytes32(uint256(1)), // key
-            bytes32(uint256(bytes32("5.2.0")) + uint256(5 * 2)) // value
-        );
+        permanentStorage.initialize(address(this));
 
         // Label addresses for easier debugging
         vm.label(user, "User");
@@ -79,13 +66,20 @@ contract PermanentStorageTest is Test {
     /*********************************
      *        Test: initialize       *
      *********************************/
+    function testCannotInitializeToZeroAddress() public {
+        PermanentStorage ps = new PermanentStorage();
+        vm.expectRevert("PermanentStorage: operator can not be zero address");
+        ps.initialize(address(0));
+    }
 
     function testCannotInitializeAgain() public {
-        permanentStorage.initialize();
-        assertEq(permanentStorage.version(), "5.3.0");
+        PermanentStorage ps = new PermanentStorage();
+        ps.initialize(address(this));
+        assertEq(ps.version(), "5.3.0");
+        assertEq(ps.operator(), address(this));
 
-        vm.expectRevert("PermanentStorage: not upgrading from 5.2.0 version");
-        permanentStorage.initialize();
+        vm.expectRevert("PermanentStorage: not upgrading from empty");
+        ps.initialize(address(this));
     }
 
     /***********************************

--- a/contracts/test/UserProxy.t.sol
+++ b/contracts/test/UserProxy.t.sol
@@ -54,9 +54,9 @@ contract UserProxyTest is Test {
      *********************************/
 
     function testCannotInitializeToZeroAddress() public {
-        UserProxy us = new UserProxy();
+        UserProxy up = new UserProxy();
         vm.expectRevert("UserProxy: operator can not be zero address");
-        us.initialize(address(0));
+        up.initialize(address(0));
     }
 
     function testCannotInitializeAgain() public {

--- a/contracts/test/UserProxy.t.sol
+++ b/contracts/test/UserProxy.t.sol
@@ -19,21 +19,8 @@ contract UserProxyTest is Test {
         // Deploy
         userProxy = new UserProxy();
         strategy = new MockStrategy();
-        // Setup
         // Set this contract as operator
-        // prettier-ignore
-        vm.store(
-            address(userProxy), // address
-            bytes32(uint256(0)), // key
-            bytes32(uint256(address(this))) // value
-        );
-        // Set version
-        // prettier-ignore
-        vm.store(
-            address(userProxy), // address
-            bytes32(uint256(1)), // key
-            bytes32(uint256(bytes32("5.2.0")) + uint256(5 * 2)) // value
-        );
+        userProxy.initialize(address(this));
 
         // Deal 100 ETH to each account
         deal(user, 100 ether);
@@ -67,15 +54,19 @@ contract UserProxyTest is Test {
      *********************************/
 
     function testCannotInitializeToZeroAddress() public {
-        vm.expectRevert("UserProxy: _limitOrderAddr should not be 0");
-        userProxy.initialize(address(0));
+        UserProxy us = new UserProxy();
+        vm.expectRevert("UserProxy: operator can not be zero address");
+        us.initialize(address(0));
     }
 
     function testCannotInitializeAgain() public {
-        userProxy.initialize(address(this));
+        UserProxy up = new UserProxy();
+        up.initialize(address(this));
+        assertEq(up.version(), "5.3.0");
+        assertEq(up.operator(), address(this));
 
-        vm.expectRevert("UserProxy: not upgrading from version 5.2.0");
-        userProxy.initialize(address(this));
+        vm.expectRevert("UserProxy: not upgrading from empty");
+        up.initialize(address(this));
     }
 
     /***************************************************

--- a/contracts/test/utils/StrategySharedSetup.sol
+++ b/contracts/test/utils/StrategySharedSetup.sol
@@ -35,22 +35,8 @@ contract StrategySharedSetup is BalanceUtil, RegisterCurveIndexes {
             bytes("") // Skip initialization during deployment
         );
         userProxy = UserProxy(address(tokenlon));
-
-        // Setup
         // Set this contract as operator
-        // prettier-ignore
-        vm.store(
-            address(userProxy), // address
-            bytes32(uint256(0)), // key
-            bytes32(uint256(address(this))) // value
-        );
-        // Set version
-        // prettier-ignore
-        vm.store(
-            address(userProxy), // address
-            bytes32(uint256(1)), // key
-            bytes32(uint256(bytes32("5.2.0")) + uint256(5 * 2)) // value
-        );
+        userProxy.initialize(address(this));
     }
 
     function _deployPermanentStorageAndProxy() internal {
@@ -61,22 +47,8 @@ contract StrategySharedSetup is BalanceUtil, RegisterCurveIndexes {
             bytes("") // Skip initialization during deployment
         );
         permanentStorage = PermanentStorage(address(permanentStorageProxy));
-
-        // Setup
         // Set this contract as operator
-        // prettier-ignore
-        vm.store(
-            address(permanentStorage), // address
-            bytes32(uint256(0)), // key
-            bytes32(uint256(address(this))) // value
-        );
-        // Set version
-        // prettier-ignore
-        vm.store(
-            address(permanentStorage), // address
-            bytes32(uint256(1)), // key
-            bytes32(uint256(bytes32("5.2.0")) + uint256(5 * 2)) // value
-        );
+        permanentStorage.initialize(address(this));
         permanentStorage.upgradeWETH(WETH_ADDRESS);
         // Set Curve indexes
         permanentStorage.setPermission(permanentStorage.curveTokenIndexStorageId(), address(this), true);


### PR DESCRIPTION
~According to Tokenlon contract version control policy, remove version stored in contract. Protect `initialize` function being called twice using `Initializable` contract from OZ. Set operator in `initialize` function.~

Adjust init function for new network deployment. May change design in the future.