### PR TITLE
v5.2.0 diff

### DIFF
--- a/contracts/PermanentStorage.sol
+++ b/contracts/PermanentStorage.sol
@@ -1,15 +1,16 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.7.6;
+
+pragma solidity ^0.6.5;
 
 import "./interfaces/IPermanentStorage.sol";
-import "./utils/PSStorage.sol";
+import "./utils/lib_storage/PSStorage.sol";
 
 contract PermanentStorage is IPermanentStorage {
+
     // Constants do not have storage slot.
     bytes32 public constant curveTokenIndexStorageId = 0xf4c750cdce673f6c35898d215e519b86e3846b1f0532fb48b84fe9d80f6de2fc; // keccak256("curveTokenIndex")
-    bytes32 public constant transactionSeenStorageId = 0x695d523b8578c6379a2121164fd8de334b9c5b6b36dff5408bd4051a6b1704d0; // keccak256("transactionSeen")
-    bytes32 public constant relayerValidStorageId = 0x2c97779b4deaf24e9d46e02ec2699240a957d92782b51165b93878b09dd66f61; // keccak256("relayerValid")
-    bytes32 public constant allowFillSeenStorageId = 0x808188d002c47900fbb4e871d29754afff429009f6684806712612d807395dd8; // keccak256("allowFillSeen")
+    bytes32 public constant transactionSeenStorageId = 0x695d523b8578c6379a2121164fd8de334b9c5b6b36dff5408bd4051a6b1704d0;  // keccak256("transactionSeen")
+    bytes32 public constant relayerValidStorageId = 0x2c97779b4deaf24e9d46e02ec2699240a957d92782b51165b93878b09dd66f61;  // keccak256("relayerValid")
 
     // New supported Curve pools
     address public constant CURVE_renBTC_POOL = 0x93054188d876f558f4a66B2EF1d97d16eDf0895B;
@@ -27,8 +28,9 @@ contract PermanentStorage is IPermanentStorage {
 
     // Below are the variables which consume storage slots.
     address public operator;
-    string public version; // Current version of the contract
+    string public version;  // Current version of the contract
     mapping(bytes32 => mapping(address => bool)) private permission;
+
 
     // Operator events
     event TransferOwnership(address newOperator);
@@ -36,14 +38,12 @@ contract PermanentStorage is IPermanentStorage {
     event UpgradeAMMWrapper(address newAMMWrapper);
     event UpgradePMM(address newPMM);
     event UpgradeRFQ(address newRFQ);
-    event UpgradeLimitOrder(address newLimitOrder);
     event UpgradeWETH(address newWETH);
-    event SetCurvePoolInfo(address makerAddr, address[] underlyingCoins, address[] coins, bool supportGetD);
-    event SetRelayerValid(address relayer, bool valid);
+
 
     /************************************************************
-     *          Access control and ownership management          *
-     *************************************************************/
+    *          Access control and ownership management          *
+    *************************************************************/
     modifier onlyOperator() {
         require(operator == msg.sender, "PermanentStorage: not the operator");
         _;
@@ -52,7 +52,7 @@ contract PermanentStorage is IPermanentStorage {
     modifier validRole(bool _enabled, address _role) {
         if (_enabled) {
             require(
-                (_role == operator) || (_role == ammWrapperAddr()) || (_role == pmmAddr()) || (_role == rfqAddr()) || (_role == limitOrderAddr()),
+                (_role == operator) || (_role == ammWrapperAddr()) || (_role == pmmAddr() || (_role == rfqAddr())),
                 "PermanentStorage: not a valid role"
             );
         }
@@ -64,6 +64,7 @@ contract PermanentStorage is IPermanentStorage {
         _;
     }
 
+
     function transferOwnership(address _newOperator) external onlyOperator {
         require(_newOperator != address(0), "PermanentStorage: operator can not be zero address");
         operator = _newOperator;
@@ -72,32 +73,54 @@ contract PermanentStorage is IPermanentStorage {
     }
 
     /// @dev Set permission for entity to write certain storage.
-    function setPermission(
-        bytes32 _storageId,
-        address _role,
-        bool _enabled
-    ) external onlyOperator validRole(_enabled, _role) {
+    function setPermission(bytes32 _storageId, address _role, bool _enabled) external onlyOperator validRole(_enabled, _role) {
         permission[_storageId][_role] = _enabled;
 
         emit SetPermission(_storageId, _role, _enabled);
     }
 
-    /************************************************************
-     *              Constructor and init functions               *
-     *************************************************************/
-    /// @dev Replacing constructor and initialize the contract. This function should only be called once.
-    function initialize(address _operator) external {
-        require(keccak256(abi.encodePacked(version)) == keccak256(abi.encodePacked("")), "PermanentStorage: not upgrading from empty");
-        require(_operator != address(0), "PermanentStorage: operator can not be zero address");
-        operator = _operator;
 
-        // Upgrade version
-        version = "5.3.0";
+    /************************************************************
+    *              Constructor and init functions               *
+    *************************************************************/
+    /// @dev Replacing constructor and initialize the contract. This function should only be called once.
+    function initialize() external {
+        require(
+            keccak256(abi.encodePacked(version)) == keccak256(abi.encodePacked("5.1.0")),
+            "PermanentStorage: not upgrading from 5.1.0 version"
+        );
+        // upgrade from 5.1.0 to 5.2.0
+        version = "5.2.0";
+        // register renBTC pool
+        // coins, exchange
+        AMMWrapperStorage.getStorage().curveWrappedTokenIndexes[CURVE_renBTC_POOL][renBTC] = 1; // renBTC
+        AMMWrapperStorage.getStorage().curveWrappedTokenIndexes[CURVE_renBTC_POOL][wBTC] = 2; // wBTC
+        AMMWrapperStorage.getStorage().curveSupportGetDx[CURVE_renBTC_POOL] = false;
+
+        // register sBTC pool
+        // coins, exchange
+        AMMWrapperStorage.getStorage().curveWrappedTokenIndexes[CURVE_sBTC_POOL][renBTC] = 1; // renBTC
+        AMMWrapperStorage.getStorage().curveWrappedTokenIndexes[CURVE_sBTC_POOL][wBTC] = 2; // wBTC
+        AMMWrapperStorage.getStorage().curveWrappedTokenIndexes[CURVE_sBTC_POOL][sBTC] = 3; // sBTC
+        AMMWrapperStorage.getStorage().curveSupportGetDx[CURVE_sBTC_POOL] = false;
+
+        // register hBTC pool
+        // coins, exchange
+        AMMWrapperStorage.getStorage().curveWrappedTokenIndexes[CURVE_hBTC_POOL][hBTC] = 1; // hBTC
+        AMMWrapperStorage.getStorage().curveWrappedTokenIndexes[CURVE_hBTC_POOL][wBTC] = 2; // wBTC
+        AMMWrapperStorage.getStorage().curveSupportGetDx[CURVE_hBTC_POOL] = false;
+
+        // register sETH pool
+        // coins, exchange
+        AMMWrapperStorage.getStorage().curveWrappedTokenIndexes[CURVE_sETH_POOL][ETH] = 1; // ETH
+        AMMWrapperStorage.getStorage().curveWrappedTokenIndexes[CURVE_sETH_POOL][sETH] = 2; // sETH
+        AMMWrapperStorage.getStorage().curveSupportGetDx[CURVE_sETH_POOL] = false;
     }
 
+
     /************************************************************
-     *                     Getter functions                      *
-     *************************************************************/
+    *                     Getter functions                      *
+    *************************************************************/
     function hasPermission(bytes32 _storageId, address _role) external view returns (bool) {
         return permission[_storageId][_role];
     }
@@ -114,29 +137,11 @@ contract PermanentStorage is IPermanentStorage {
         return PSStorage.getStorage().rfqAddr;
     }
 
-    function limitOrderAddr() public view returns (address) {
-        return PSStorage.getStorage().limitOrderAddr;
-    }
-
-    function wethAddr() external view override returns (address) {
+    function wethAddr() override external view returns (address) {
         return PSStorage.getStorage().wethAddr;
     }
 
-    function getCurvePoolInfo(
-        address _makerAddr,
-        address _takerAssetAddr,
-        address _makerAssetAddr
-    )
-        external
-        view
-        override
-        returns (
-            int128 takerAssetIndex,
-            int128 makerAssetIndex,
-            uint16 swapMethod,
-            bool supportGetDx
-        )
-    {
+    function getCurvePoolInfo(address _makerAddr, address _takerAssetAddr, address _makerAssetAddr) override external view returns (int128 takerAssetIndex, int128 makerAssetIndex, uint16 swapMethod, bool supportGetDx) {
         // underlying_coins
         int128 i = AMMWrapperStorage.getStorage().curveTokenIndexes[_makerAddr][_takerAssetAddr];
         int128 j = AMMWrapperStorage.getStorage().curveTokenIndexes[_makerAddr][_makerAssetAddr];
@@ -169,33 +174,26 @@ contract PermanentStorage is IPermanentStorage {
     NOTE: `isTransactionSeen` is replaced by `isAMMTransactionSeen`. It is kept for backward compatability.
     It should be removed from AMM 5.2.1 upward.
     */
-    function isTransactionSeen(bytes32 _transactionHash) external view override returns (bool) {
+    function isTransactionSeen(bytes32 _transactionHash) override external view returns (bool) {
         return AMMWrapperStorage.getStorage().transactionSeen[_transactionHash];
     }
 
-    function isAMMTransactionSeen(bytes32 _transactionHash) external view override returns (bool) {
+    function isAMMTransactionSeen(bytes32 _transactionHash) override external view returns (bool) {
         return AMMWrapperStorage.getStorage().transactionSeen[_transactionHash];
     }
 
-    function isRFQTransactionSeen(bytes32 _transactionHash) external view override returns (bool) {
+    function isRFQTransactionSeen(bytes32 _transactionHash) override external view returns (bool) {
         return RFQStorage.getStorage().transactionSeen[_transactionHash];
     }
 
-    function isLimitOrderTransactionSeen(bytes32 _transactionHash) external view override returns (bool) {
-        return LimitOrderStorage.getStorage().transactionSeen[_transactionHash];
-    }
-
-    function isLimitOrderAllowFillSeen(bytes32 _allowFillHash) external view override returns (bool) {
-        return LimitOrderStorage.getStorage().allowFillSeen[_allowFillHash];
-    }
-
-    function isRelayerValid(address _relayer) external view override returns (bool) {
+    function isRelayerValid(address _relayer) override external view returns (bool) {
         return AMMWrapperStorage.getStorage().relayerValid[_relayer];
     }
 
+
     /************************************************************
-     *           Management functions for Operator               *
-     *************************************************************/
+    *           Management functions for Operator               *
+    *************************************************************/
     /// @dev Update AMMWrapper contract address.
     function upgradeAMMWrapper(address _newAMMWrapper) external onlyOperator {
         PSStorage.getStorage().ammWrapperAddr = _newAMMWrapper;
@@ -217,13 +215,6 @@ contract PermanentStorage is IPermanentStorage {
         emit UpgradeRFQ(_newRFQ);
     }
 
-    /// @dev Update Limit Order contract address.
-    function upgradeLimitOrder(address _newLimitOrder) external onlyOperator {
-        PSStorage.getStorage().limitOrderAddr = _newLimitOrder;
-
-        emit UpgradeLimitOrder(_newLimitOrder);
-    }
-
     /// @dev Update WETH contract address.
     function upgradeWETH(address _newWETH) external onlyOperator {
         PSStorage.getStorage().wethAddr = _newWETH;
@@ -231,67 +222,51 @@ contract PermanentStorage is IPermanentStorage {
         emit UpgradeWETH(_newWETH);
     }
 
+
     /************************************************************
-     *                   External functions                      *
-     *************************************************************/
-    function setCurvePoolInfo(
-        address _makerAddr,
-        address[] calldata _underlyingCoins,
-        address[] calldata _coins,
-        bool _supportGetDx
-    ) external override isPermitted(curveTokenIndexStorageId, msg.sender) {
+    *                   External functions                      *
+    *************************************************************/
+    function setCurvePoolInfo(address _makerAddr, address[] calldata _underlyingCoins, address[] calldata _coins, bool _supportGetDx) override external isPermitted(curveTokenIndexStorageId, msg.sender) {
         int128 underlyingCoinsLength = int128(_underlyingCoins.length);
-        for (int128 i = 0; i < underlyingCoinsLength; i++) {
+        for (int128 i = 0 ; i < underlyingCoinsLength; i++) {
             address assetAddr = _underlyingCoins[uint256(i)];
             // underlying coins for original DAI, USDC, TUSD
-            AMMWrapperStorage.getStorage().curveTokenIndexes[_makerAddr][assetAddr] = i + 1; // Start the index from 1
+            AMMWrapperStorage.getStorage().curveTokenIndexes[_makerAddr][assetAddr] = i + 1;  // Start the index from 1
         }
 
         int128 coinsLength = int128(_coins.length);
-        for (int128 i = 0; i < coinsLength; i++) {
+        for (int128 i = 0 ; i < coinsLength; i++) {
             address assetAddr = _coins[uint256(i)];
             // wrapped coins for cDAI, cUSDC, yDAI, yUSDC, yTUSD, yBUSD
-            AMMWrapperStorage.getStorage().curveWrappedTokenIndexes[_makerAddr][assetAddr] = i + 1; // Start the index from 1
+            AMMWrapperStorage.getStorage().curveWrappedTokenIndexes[_makerAddr][assetAddr] = i + 1;  // Start the index from 1
         }
 
         AMMWrapperStorage.getStorage().curveSupportGetDx[_makerAddr] = _supportGetDx;
-        emit SetCurvePoolInfo(_makerAddr, _underlyingCoins, _coins, _supportGetDx);
     }
 
     /* 
     NOTE: `setTransactionSeen` is replaced by `setAMMTransactionSeen`. It is kept for backward compatability.
     It should be removed from AMM 5.2.1 upward.
     */
-    function setTransactionSeen(bytes32 _transactionHash) external override isPermitted(transactionSeenStorageId, msg.sender) {
+    function setTransactionSeen(bytes32 _transactionHash) override external isPermitted(transactionSeenStorageId, msg.sender) {
         require(!AMMWrapperStorage.getStorage().transactionSeen[_transactionHash], "PermanentStorage: transaction seen before");
         AMMWrapperStorage.getStorage().transactionSeen[_transactionHash] = true;
     }
 
-    function setAMMTransactionSeen(bytes32 _transactionHash) external override isPermitted(transactionSeenStorageId, msg.sender) {
+    function setAMMTransactionSeen(bytes32 _transactionHash) override external isPermitted(transactionSeenStorageId, msg.sender) {
         require(!AMMWrapperStorage.getStorage().transactionSeen[_transactionHash], "PermanentStorage: transaction seen before");
         AMMWrapperStorage.getStorage().transactionSeen[_transactionHash] = true;
     }
 
-    function setRFQTransactionSeen(bytes32 _transactionHash) external override isPermitted(transactionSeenStorageId, msg.sender) {
+    function setRFQTransactionSeen(bytes32 _transactionHash) override external isPermitted(transactionSeenStorageId, msg.sender) {
         require(!RFQStorage.getStorage().transactionSeen[_transactionHash], "PermanentStorage: transaction seen before");
         RFQStorage.getStorage().transactionSeen[_transactionHash] = true;
     }
 
-    function setLimitOrderTransactionSeen(bytes32 _transactionHash) external override isPermitted(transactionSeenStorageId, msg.sender) {
-        require(!LimitOrderStorage.getStorage().transactionSeen[_transactionHash], "PermanentStorage: transaction seen before");
-        LimitOrderStorage.getStorage().transactionSeen[_transactionHash] = true;
-    }
-
-    function setLimitOrderAllowFillSeen(bytes32 _allowFillHash) external override isPermitted(allowFillSeenStorageId, msg.sender) {
-        require(!LimitOrderStorage.getStorage().allowFillSeen[_allowFillHash], "PermanentStorage: allow fill seen before");
-        LimitOrderStorage.getStorage().allowFillSeen[_allowFillHash] = true;
-    }
-
-    function setRelayersValid(address[] calldata _relayers, bool[] calldata _isValids) external override isPermitted(relayerValidStorageId, msg.sender) {
+    function setRelayersValid(address[] calldata _relayers, bool[] calldata _isValids) override external isPermitted(relayerValidStorageId, msg.sender) {
         require(_relayers.length == _isValids.length, "PermanentStorage: inputs length mismatch");
         for (uint256 i = 0; i < _relayers.length; i++) {
             AMMWrapperStorage.getStorage().relayerValid[_relayers[i]] = _isValids[i];
-            emit SetRelayerValid(_relayers[i], _isValids[i]);
         }
     }
 }

--- a/contracts/Tokenlon.sol
+++ b/contracts/Tokenlon.sol
@@ -1,11 +1,9 @@
-pragma solidity 0.7.6;
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.0;
 
 import "./upgrade_proxy/TransparentUpgradeableProxy.sol";
 
 contract Tokenlon is TransparentUpgradeableProxy {
-    constructor(
-        address _logic,
-        address _admin,
-        bytes memory _data
-    ) public payable TransparentUpgradeableProxy(_logic, _admin, _data) {}
+    constructor(address _logic, address _admin, bytes memory _data) public payable TransparentUpgradeableProxy(_logic, _admin, _data) {}
 }

--- a/contracts/interfaces/IAllowanceTarget.sol
+++ b/contracts/interfaces/IAllowanceTarget.sol
@@ -1,11 +1,8 @@
-pragma solidity >=0.7.0;
+pragma solidity ^0.6.0;
 
 interface IAllowanceTarget {
     function setSpenderWithTimelock(address _newSpender) external;
-
     function completeSetSpender() external;
-
     function executeCall(address payable _target, bytes calldata _callData) external returns (bytes memory resultData);
-
     function teardown() external;
 }

--- a/contracts/interfaces/IPermanentStorage.sol
+++ b/contracts/interfaces/IPermanentStorage.sol
@@ -1,50 +1,15 @@
-pragma solidity >=0.7.0;
+pragma solidity ^0.6.0;
 
 interface IPermanentStorage {
     function wethAddr() external view returns (address);
-
-    function getCurvePoolInfo(
-        address _makerAddr,
-        address _takerAssetAddr,
-        address _makerAssetAddr
-    )
-        external
-        view
-        returns (
-            int128 takerAssetIndex,
-            int128 makerAssetIndex,
-            uint16 swapMethod,
-            bool supportGetDx
-        );
-
-    function setCurvePoolInfo(
-        address _makerAddr,
-        address[] calldata _underlyingCoins,
-        address[] calldata _coins,
-        bool _supportGetDx
-    ) external;
-
-    function isTransactionSeen(bytes32 _transactionHash) external view returns (bool); // Kept for backward compatability. Should be removed from AMM 5.2.1 upward
-
+    function getCurvePoolInfo(address _makerAddr, address _takerAssetAddr, address _makerAssetAddr) external view returns (int128 takerAssetIndex, int128 makerAssetIndex, uint16 swapMethod, bool supportGetDx);
+    function setCurvePoolInfo(address _makerAddr, address[] calldata _underlyingCoins, address[] calldata _coins, bool _supportGetDx) external;
+    function isTransactionSeen(bytes32 _transactionHash) external view returns (bool);  // Kept for backward compatability. Should be removed from AMM 5.2.1 upward
     function isAMMTransactionSeen(bytes32 _transactionHash) external view returns (bool);
-
     function isRFQTransactionSeen(bytes32 _transactionHash) external view returns (bool);
-
-    function isLimitOrderTransactionSeen(bytes32 _transactionHash) external view returns (bool);
-
-    function isLimitOrderAllowFillSeen(bytes32 _allowFillHash) external view returns (bool);
-
     function isRelayerValid(address _relayer) external view returns (bool);
-
-    function setTransactionSeen(bytes32 _transactionHash) external; // Kept for backward compatability. Should be removed from AMM 5.2.1 upward
-
+    function setTransactionSeen(bytes32 _transactionHash) external;  // Kept for backward compatability. Should be removed from AMM 5.2.1 upward
     function setAMMTransactionSeen(bytes32 _transactionHash) external;
-
     function setRFQTransactionSeen(bytes32 _transactionHash) external;
-
-    function setLimitOrderTransactionSeen(bytes32 _transactionHash) external;
-
-    function setLimitOrderAllowFillSeen(bytes32 _allowFillHash) external;
-
     function setRelayersValid(address[] memory _relayers, bool[] memory _isValids) external;
 }

--- a/contracts/upgrade_proxy/Proxy.sol
+++ b/contracts/upgrade_proxy/Proxy.sol
@@ -1,21 +1,21 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.7.6;
+pragma solidity ^0.6.0;
 
 /**
  * @dev This abstract contract provides a fallback function that delegates all calls to another contract using the EVM
  * instruction `delegatecall`. We refer to the second contract as the _implementation_ behind the proxy, and it has to
  * be specified by overriding the virtual {_implementation} function.
- *
+ * 
  * Additionally, delegation to the implementation can be triggered manually through the {_fallback} function, or to a
  * different contract through the {_delegate} function.
- *
+ * 
  * The success and return data of the delegated call will be returned back to the caller of the proxy.
  */
 abstract contract Proxy {
     /**
      * @dev Delegates the current call to `implementation`.
-     *
+     * 
      * This function does not return to its internall call site, it will return directly to the external caller.
      */
     function _delegate(address implementation) internal {
@@ -35,12 +35,8 @@ abstract contract Proxy {
 
             switch result
             // delegatecall returns 0 on error.
-            case 0 {
-                revert(0, returndatasize())
-            }
-            default {
-                return(0, returndatasize())
-            }
+            case 0 { revert(0, returndatasize()) }
+            default { return(0, returndatasize()) }
         }
     }
 
@@ -48,11 +44,11 @@ abstract contract Proxy {
      * @dev This is a virtual function that should be overriden so it returns the address to which the fallback function
      * and {_fallback} should delegate.
      */
-    function _implementation() internal view virtual returns (address);
+    function _implementation() internal virtual view returns (address);
 
     /**
      * @dev Delegates the current call to the address returned by `_implementation()`.
-     *
+     * 
      * This function does not return to its internall call site, it will return directly to the external caller.
      */
     function _fallback() internal {
@@ -64,7 +60,7 @@ abstract contract Proxy {
      * @dev Fallback function that delegates calls to the address returned by `_implementation()`. Will run if no other
      * function in the contract matches the call data.
      */
-    fallback() external payable {
+    fallback () payable external {
         _fallback();
     }
 
@@ -72,15 +68,16 @@ abstract contract Proxy {
      * @dev Fallback function that delegates calls to the address returned by `_implementation()`. Will run if call data
      * is empty.
      */
-    receive() external payable {
+    receive () payable external {
         _fallback();
     }
 
     /**
      * @dev Hook that is called before falling back to the implementation. Can happen as part of a manual `_fallback`
      * call, or as part of the Solidity `fallback` or `receive` functions.
-     *
+     * 
      * If overriden should call `super._beforeFallback()`.
      */
-    function _beforeFallback() internal virtual {}
+    function _beforeFallback() internal virtual {
+    }
 }

--- a/contracts/upgrade_proxy/TransparentUpgradeableProxy.sol
+++ b/contracts/upgrade_proxy/TransparentUpgradeableProxy.sol
@@ -1,27 +1,27 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.7.6;
+pragma solidity ^0.6.0;
 
 import "./UpgradeableProxy.sol";
 
 /**
  * @dev This contract implements a proxy that is upgradeable by an admin.
- *
+ * 
  * To avoid https://medium.com/nomic-labs-blog/malicious-backdoors-in-ethereum-proxies-62629adf3357[proxy selector
  * clashing], which can potentially be used in an attack, this contract uses the
  * https://blog.openzeppelin.com/the-transparent-proxy-pattern/[transparent proxy pattern]. This pattern implies two
  * things that go hand in hand:
- *
+ * 
  * 1. If any account other than the admin calls the proxy, the call will be forwarded to the implementation, even if
  * that call matches one of the admin functions exposed by the proxy itself.
  * 2. If the admin calls the proxy, it can access the admin functions, but its calls will never be forwarded to the
  * implementation. If the admin tries to call a function on the implementation it will fail with an error that says
  * "admin cannot fallback to proxy target".
- *
+ * 
  * These properties mean that the admin account can only be used for admin actions like upgrading the proxy or changing
  * the admin, so it's best if it's a dedicated account that is not used for anything else. This will avoid headaches due
  * to sudden errors when trying to call a function from the proxy implementation.
- *
+ * 
  * Our recommendation is for the dedicated account to be an instance of the {ProxyAdmin} contract. If set up this way,
  * you should think of the `ProxyAdmin` instance as the real administrative interface of your proxy.
  */
@@ -30,11 +30,7 @@ contract TransparentUpgradeableProxy is UpgradeableProxy {
      * @dev Initializes an upgradeable proxy managed by `_admin`, backed by the implementation at `_logic`, and
      * optionally initialized with `_data` as explained in {UpgradeableProxy-constructor}.
      */
-    constructor(
-        address _logic,
-        address _admin,
-        bytes memory _data
-    ) payable UpgradeableProxy(_logic, _data) {
+    constructor(address _logic, address _admin, bytes memory _data) public payable UpgradeableProxy(_logic, _data) {
         assert(_ADMIN_SLOT == bytes32(uint256(keccak256("eip1967.proxy.admin")) - 1));
         _setAdmin(_admin);
     }
@@ -64,9 +60,9 @@ contract TransparentUpgradeableProxy is UpgradeableProxy {
 
     /**
      * @dev Returns the current admin.
-     *
+     * 
      * NOTE: Only the admin can call this function. See {ProxyAdmin-getProxyAdmin}.
-     *
+     * 
      * TIP: To get this value clients can read directly from the storage slot shown below (specified by EIP1967) using the
      * https://eth.wiki/json-rpc/API#eth_getstorageat[`eth_getStorageAt`] RPC call.
      * `0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103`
@@ -77,9 +73,9 @@ contract TransparentUpgradeableProxy is UpgradeableProxy {
 
     /**
      * @dev Returns the current implementation.
-     *
+     * 
      * NOTE: Only the admin can call this function. See {ProxyAdmin-getProxyImplementation}.
-     *
+     * 
      * TIP: To get this value clients can read directly from the storage slot shown below (specified by EIP1967) using the
      * https://eth.wiki/json-rpc/API#eth_getstorageat[`eth_getStorageAt`] RPC call.
      * `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc`
@@ -90,9 +86,9 @@ contract TransparentUpgradeableProxy is UpgradeableProxy {
 
     /**
      * @dev Changes the admin of the proxy.
-     *
+     * 
      * Emits an {AdminChanged} event.
-     *
+     * 
      * NOTE: Only the admin can call this function. See {ProxyAdmin-changeProxyAdmin}.
      */
     function changeAdmin(address newAdmin) external ifAdmin {
@@ -103,7 +99,7 @@ contract TransparentUpgradeableProxy is UpgradeableProxy {
 
     /**
      * @dev Upgrade the implementation of the proxy.
-     *
+     * 
      * NOTE: Only the admin can call this function. See {ProxyAdmin-upgrade}.
      */
     function upgradeTo(address newImplementation) external ifAdmin {
@@ -114,13 +110,13 @@ contract TransparentUpgradeableProxy is UpgradeableProxy {
      * @dev Upgrade the implementation of the proxy, and then call a function from the new implementation as specified
      * by `data`, which should be an encoded function call. This is useful to initialize new storage variables in the
      * proxied contract.
-     *
+     * 
      * NOTE: Only the admin can call this function. See {ProxyAdmin-upgradeAndCall}.
      */
     function upgradeToAndCall(address newImplementation, bytes calldata data) external payable ifAdmin {
         _upgradeTo(newImplementation);
         // solhint-disable-next-line avoid-low-level-calls
-        (bool success, ) = newImplementation.delegatecall(data);
+        (bool success,) = newImplementation.delegatecall(data);
         require(success);
     }
 
@@ -150,7 +146,7 @@ contract TransparentUpgradeableProxy is UpgradeableProxy {
     /**
      * @dev Makes sure the admin cannot access the fallback function. See {Proxy-_beforeFallback}.
      */
-    function _beforeFallback() internal virtual override {
+    function _beforeFallback() internal override virtual {
         require(msg.sender != _admin(), "TransparentUpgradeableProxy: admin cannot fallback to proxy target");
         super._beforeFallback();
     }

--- a/contracts/upgrade_proxy/UpgradeableProxy.sol
+++ b/contracts/upgrade_proxy/UpgradeableProxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.7.6;
+pragma solidity ^0.6.0;
 
 import "@openzeppelin/contracts/utils/Address.sol";
 
@@ -11,23 +11,23 @@ import "./Proxy.sol";
  * implementation address that can be changed. This address is stored in storage in the location specified by
  * https://eips.ethereum.org/EIPS/eip-1967[EIP1967], so that it doesn't conflict with the storage layout of the
  * implementation behind the proxy.
- *
+ * 
  * Upgradeability is only provided internally through {_upgradeTo}. For an externally upgradeable proxy see
  * {TransparentUpgradeableProxy}.
  */
 contract UpgradeableProxy is Proxy {
     /**
      * @dev Initializes the upgradeable proxy with an initial implementation specified by `_logic`.
-     *
+     * 
      * If `_data` is nonempty, it's used as data in a delegate call to `_logic`. This will typically be an encoded
      * function call, and allows initializating the storage of the proxy like a Solidity constructor.
      */
-    constructor(address _logic, bytes memory _data) payable {
+    constructor(address _logic, bytes memory _data) public payable {
         assert(_IMPLEMENTATION_SLOT == bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1));
         _setImplementation(_logic);
-        if (_data.length > 0) {
+        if(_data.length > 0) {
             // solhint-disable-next-line avoid-low-level-calls
-            (bool success, ) = _logic.delegatecall(_data);
+            (bool success,) = _logic.delegatecall(_data);
             require(success);
         }
     }
@@ -47,7 +47,7 @@ contract UpgradeableProxy is Proxy {
     /**
      * @dev Returns the current implementation address.
      */
-    function _implementation() internal view override returns (address impl) {
+    function _implementation() internal override view returns (address impl) {
         bytes32 slot = _IMPLEMENTATION_SLOT;
         // solhint-disable-next-line no-inline-assembly
         assembly {
@@ -57,7 +57,7 @@ contract UpgradeableProxy is Proxy {
 
     /**
      * @dev Upgrades the proxy to a new implementation.
-     *
+     * 
      * Emits an {Upgraded} event.
      */
     function _upgradeTo(address newImplementation) internal {

--- a/contracts/utils/PSStorage.sol
+++ b/contracts/utils/PSStorage.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.7.6;
+pragma solidity ^0.6.5;
+pragma experimental ABIEncoderV2;
 
 library PSStorage {
     bytes32 private constant STORAGE_SLOT = 0x92dd52b981a2dd69af37d8a3febca29ed6a974aede38ae66e4ef773173aba471;
@@ -8,8 +9,6 @@ library PSStorage {
         address pmmAddr;
         address wethAddr;
         address rfqAddr;
-        address limitOrderAddr;
-        address l2DepositAddr;
     }
 
     /// @dev Get the storage bucket for this contract.
@@ -20,9 +19,7 @@ library PSStorage {
         // Dip into assembly to change the slot pointed to by the local
         // variable `stor`.
         // See https://solidity.readthedocs.io/en/v0.6.8/assembly.html?highlight=slot#access-to-external-variables-functions-and-libraries
-        assembly {
-            stor.slot := slot
-        }
+        assembly { stor_slot := slot }
     }
 }
 
@@ -48,9 +45,7 @@ library AMMWrapperStorage {
         // Dip into assembly to change the slot pointed to by the local
         // variable `stor`.
         // See https://solidity.readthedocs.io/en/v0.6.8/assembly.html?highlight=slot#access-to-external-variables-functions-and-libraries
-        assembly {
-            stor.slot := slot
-        }
+        assembly { stor_slot := slot }
     }
 }
 
@@ -69,30 +64,6 @@ library RFQStorage {
         // Dip into assembly to change the slot pointed to by the local
         // variable `stor`.
         // See https://solidity.readthedocs.io/en/v0.6.8/assembly.html?highlight=slot#access-to-external-variables-functions-and-libraries
-        assembly {
-            stor.slot := slot
-        }
-    }
-}
-
-library LimitOrderStorage {
-    bytes32 private constant STORAGE_SLOT = 0xb1b5d1092eed9d9f9f6bdd5bf9fe04f7537770f37e1d84ac8960cc3acb80615c;
-
-    struct Storage {
-        mapping(bytes32 => bool) transactionSeen;
-        mapping(bytes32 => bool) allowFillSeen;
-    }
-
-    /// @dev Get the storage bucket for this contract.
-    function getStorage() internal pure returns (Storage storage stor) {
-        assert(STORAGE_SLOT == bytes32(uint256(keccak256("permanent.limitorder.storage")) - 1));
-        bytes32 slot = STORAGE_SLOT;
-
-        // Dip into assembly to change the slot pointed to by the local
-        // variable `stor`.
-        // See https://solidity.readthedocs.io/en/v0.6.8/assembly.html?highlight=slot#access-to-external-variables-functions-and-libraries
-        assembly {
-            stor.slot := slot
-        }
+        assembly { stor_slot := slot }
     }
 }

--- a/contracts/utils/UserProxyStorage.sol
+++ b/contracts/utils/UserProxyStorage.sol
@@ -1,7 +1,9 @@
-pragma solidity ^0.7.6;
+pragma solidity ^0.6.5;
+pragma experimental ABIEncoderV2;
 
 library AMMWrapperStorage {
     bytes32 private constant STORAGE_SLOT = 0xbf49677e3150252dfa801a673d2d5ec21eaa360a4674864e55e79041e3f65a6b;
+
 
     /// @dev Storage bucket for proxy contract.
     struct Storage {
@@ -19,14 +21,13 @@ library AMMWrapperStorage {
         // Dip into assembly to change the slot pointed to by the local
         // variable `stor`.
         // See https://solidity.readthedocs.io/en/v0.6.8/assembly.html?highlight=slot#access-to-external-variables-functions-and-libraries
-        assembly {
-            stor.slot := slot
-        }
+        assembly { stor_slot := slot }
     }
 }
 
 library PMMStorage {
     bytes32 private constant STORAGE_SLOT = 0x8f135983375ba6442123d61647e7325c1753eabc2e038e44d3b888a970def89a;
+
 
     /// @dev Storage bucket for proxy contract.
     struct Storage {
@@ -44,14 +45,13 @@ library PMMStorage {
         // Dip into assembly to change the slot pointed to by the local
         // variable `stor`.
         // See https://solidity.readthedocs.io/en/v0.6.8/assembly.html?highlight=slot#access-to-external-variables-functions-and-libraries
-        assembly {
-            stor.slot := slot
-        }
+        assembly { stor_slot := slot }
     }
 }
 
 library RFQStorage {
     bytes32 private constant STORAGE_SLOT = 0x857df08bd185dc66e3cc5e11acb4e1dd65290f3fee6426f52f84e8faccf229cf;
+
 
     /// @dev Storage bucket for proxy contract.
     struct Storage {
@@ -69,33 +69,6 @@ library RFQStorage {
         // Dip into assembly to change the slot pointed to by the local
         // variable `stor`.
         // See https://solidity.readthedocs.io/en/v0.6.8/assembly.html?highlight=slot#access-to-external-variables-functions-and-libraries
-        assembly {
-            stor.slot := slot
-        }
-    }
-}
-
-library LimitOrderStorage {
-    bytes32 private constant STORAGE_SLOT = 0xf1a59a985b4002cdf0db464f05bed7182ee06372a999d820ea1883b8bf067ce5;
-
-    /// @dev Storage bucket for proxy contract.
-    struct Storage {
-        // The address of the Limit Order contract.
-        address limitOrderAddr;
-        // Is Limit Order enabled
-        bool isEnabled;
-    }
-
-    /// @dev Get the storage bucket for this contract.
-    function getStorage() internal pure returns (Storage storage stor) {
-        assert(STORAGE_SLOT == bytes32(uint256(keccak256("userproxy.limitorder.storage")) - 1));
-        bytes32 slot = STORAGE_SLOT;
-
-        // Dip into assembly to change the slot pointed to by the local
-        // variable `stor`.
-        // See https://solidity.readthedocs.io/en/v0.6.8/assembly.html?highlight=slot#access-to-external-variables-functions-and-libraries
-        assembly {
-            stor.slot := slot
-        }
+        assembly { stor_slot := slot }
     }
 }


### PR DESCRIPTION
Use contracts from the last audited v5.2.0 (private repo `7fc32f1755988ffd104841d78d455bd4caa62ef1`) targeting to current `v5.3.0-rc1`. So the direction is opposite. Most of the changes were caused by prettier formatter and `solc` upgradding.

Major Changes :
- Upgrade `solc` version from `0.6.x` to `0.7.6`.
- Fix format using prettier.
- Integrate Multicall into UserProxy.

Also, limit order added 2 conditional fee transfer since last LimitOrder audit (fe62831). This is aim to save gas when fee is zero.

Related Files :
- contracts/AllowanceTarget.sol
- contracts/Spender.sol
- contracts/UserProxy.sol
- contracts/Tokenlon.sol
- contracts/PermanentStorage.sol
- contracts/ProxyPermanentStorage.sol (newly created file, previously use `TransparentUpgradeableProxy` directly)
- contracts/LimitOrder.sol