### PR TITLE
Redefine Foundry test for AllowanceTarget contract

### DIFF
--- a/contracts/test/AllowanceTarget/CompleteSetSpender.t.sol
+++ b/contracts/test/AllowanceTarget/CompleteSetSpender.t.sol
@@ -4,12 +4,12 @@ pragma solidity 0.7.6;
 import "contracts-test/AllowanceTarget/Setup.t.sol";
 
 contract TestAllowanceTargetCompleteSetSpender is TestAllowanceTarget {
-    function testCannotCompleteBeforeSet() public {
+    function testCannotCompleteSetSpenderBeforeSet() public {
         vm.expectRevert("AllowanceTarget: no pending SetSpender");
         allowanceTarget.completeSetSpender();
     }
 
-    function testCannotCompleteTooEarly() public {
+    function testCannotCompleteSetSpenderTooEarly() public {
         allowanceTarget.setSpenderWithTimelock(newSpender);
         vm.expectRevert("AllowanceTarget: time lock not expired yet");
         allowanceTarget.completeSetSpender();

--- a/contracts/test/AllowanceTarget/CompleteSetSpender.t.sol
+++ b/contracts/test/AllowanceTarget/CompleteSetSpender.t.sol
@@ -4,18 +4,18 @@ pragma solidity 0.7.6;
 import "contracts-test/AllowanceTarget/Setup.t.sol";
 
 contract TestAllowanceTargetCompleteSetSpender is TestAllowanceTarget {
-    function testCannotCompleteSetSpenderBeforeSet() public {
+    function testCannotSetBeforeSetNew() public {
         vm.expectRevert("AllowanceTarget: no pending SetSpender");
         allowanceTarget.completeSetSpender();
     }
 
-    function testCannotCompleteSetSpenderTooEarly() public {
+    function testCannotSetTooEarly() public {
         allowanceTarget.setSpenderWithTimelock(newSpender);
         vm.expectRevert("AllowanceTarget: time lock not expired yet");
         allowanceTarget.completeSetSpender();
     }
 
-    // usually case
+    // normal case
     function testCompleteSetSpender() public {
         allowanceTarget.setSpenderWithTimelock(newSpender);
         // fast forward

--- a/contracts/test/AllowanceTarget/CompleteSetSpender.t.sol
+++ b/contracts/test/AllowanceTarget/CompleteSetSpender.t.sol
@@ -4,18 +4,17 @@ pragma solidity 0.7.6;
 import "contracts-test/AllowanceTarget/Setup.t.sol";
 
 contract TestAllowanceTargetCompleteSetSpender is TestAllowanceTarget {
-    function testCannotSetBeforeSetNew() public {
+    function testCannotCompleteBeforeSet() public {
         vm.expectRevert("AllowanceTarget: no pending SetSpender");
         allowanceTarget.completeSetSpender();
     }
 
-    function testCannotSetTooEarly() public {
+    function testCannotCompleteTooEarly() public {
         allowanceTarget.setSpenderWithTimelock(newSpender);
         vm.expectRevert("AllowanceTarget: time lock not expired yet");
         allowanceTarget.completeSetSpender();
     }
 
-    // normal case
     function testCompleteSetSpender() public {
         allowanceTarget.setSpenderWithTimelock(newSpender);
         // fast forward

--- a/contracts/test/AllowanceTarget/CompleteSetSpender.t.sol
+++ b/contracts/test/AllowanceTarget/CompleteSetSpender.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.7.6;
+
+import "contracts-test/AllowanceTarget/Setup.t.sol";
+
+contract TestAllowanceTargetCompleteSetSpender is TestAllowanceTarget {
+    function testCannotCompleteBeforeSet() public {
+        vm.expectRevert("AllowanceTarget: no pending SetSpender");
+        allowanceTarget.completeSetSpender();
+    }
+
+    function testCannotCompleteTooEarly() public {
+        allowanceTarget.setSpenderWithTimelock(newSpender);
+        vm.expectRevert("AllowanceTarget: time lock not expired yet");
+        allowanceTarget.completeSetSpender();
+    }
+
+    // usually case
+    function testCompleteSetSpender() public {
+        allowanceTarget.setSpenderWithTimelock(newSpender);
+        // fast forward
+        vm.warp(allowanceTarget.timelockExpirationTime());
+        allowanceTarget.completeSetSpender();
+        assertEq(allowanceTarget.spender(), newSpender);
+    }
+}

--- a/contracts/test/AllowanceTarget/Constructor.t.sol
+++ b/contracts/test/AllowanceTarget/Constructor.t.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.7.6;
+
+import "contracts-test/AllowanceTarget/Setup.t.sol";
+
+contract TestAllowanceTargetConstructor is TestAllowanceTarget {
+    function testCannotDeployByZeroAddress() public {
+        vm.expectRevert("AllowanceTarget: _spender should not be 0");
+        allowanceTarget = new AllowanceTarget(address(0));
+    }
+
+    // usually case
+    function testConstructor() public {
+        assertEq(allowanceTarget.spender(), address(this));
+    }
+}

--- a/contracts/test/AllowanceTarget/Constructor.t.sol
+++ b/contracts/test/AllowanceTarget/Constructor.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.7.6;
 import "contracts-test/AllowanceTarget/Setup.t.sol";
 
 contract TestAllowanceTargetConstructor is TestAllowanceTarget {
-    function testCannotDeployByZeroAddress() public {
+    function testCannotConstructorByZeroAddress() public {
         vm.expectRevert("AllowanceTarget: _spender should not be 0");
         allowanceTarget = new AllowanceTarget(address(0));
     }

--- a/contracts/test/AllowanceTarget/Constructor.t.sol
+++ b/contracts/test/AllowanceTarget/Constructor.t.sol
@@ -4,13 +4,13 @@ pragma solidity 0.7.6;
 import "contracts-test/AllowanceTarget/Setup.t.sol";
 
 contract TestAllowanceTargetConstructor is TestAllowanceTarget {
-    function testCannotConstructorByZeroAddress() public {
+    function testCannotAllowanceTargetConstructorByZeroAddress() public {
         vm.expectRevert("AllowanceTarget: _spender should not be 0");
         allowanceTarget = new AllowanceTarget(address(0));
     }
 
     // usually case
-    function testConstructor() public {
+    function testAllowanceTargetConstructor() public {
         assertEq(allowanceTarget.spender(), address(this));
     }
 }

--- a/contracts/test/AllowanceTarget/Constructor.t.sol
+++ b/contracts/test/AllowanceTarget/Constructor.t.sol
@@ -4,13 +4,13 @@ pragma solidity 0.7.6;
 import "contracts-test/AllowanceTarget/Setup.t.sol";
 
 contract TestAllowanceTargetConstructor is TestAllowanceTarget {
-    function testCannotAllowanceTargetConstructorByZeroAddress() public {
+    function testCannotConstructByZeroAddress() public {
         vm.expectRevert("AllowanceTarget: _spender should not be 0");
         allowanceTarget = new AllowanceTarget(address(0));
     }
 
-    // usually case
-    function testAllowanceTargetConstructor() public {
+    // normal case
+    function testConstructor() public {
         assertEq(allowanceTarget.spender(), address(this));
     }
 }

--- a/contracts/test/AllowanceTarget/Constructor.t.sol
+++ b/contracts/test/AllowanceTarget/Constructor.t.sol
@@ -9,7 +9,6 @@ contract TestAllowanceTargetConstructor is TestAllowanceTarget {
         allowanceTarget = new AllowanceTarget(address(0));
     }
 
-    // normal case
     function testConstructor() public {
         assertEq(allowanceTarget.spender(), address(this));
     }

--- a/contracts/test/AllowanceTarget/ExecuteCall.t.sol
+++ b/contracts/test/AllowanceTarget/ExecuteCall.t.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.7.6;
+
+import "contracts-test/AllowanceTarget/Setup.t.sol";
+import "contracts-test/utils/BalanceSnapshot.sol";
+import "contracts-test/mocks/MockERC20.sol";
+
+contract TestAllowanceTargetExecuteCall is TestAllowanceTarget {
+    // include Snapshot struct from BalanceSnapshot
+    using BalanceSnapshot for BalanceSnapshot.Snapshot;
+
+    function testCannotExecuteByNotSpender() public {
+        vm.prank(bob);
+        vm.expectRevert("AllowanceTarget: not the spender");
+
+        bytes memory data;
+        allowanceTarget.executeCall(payable(address(newSpender)), data);
+    }
+
+    // usually case
+    function testExecuteCall() public {
+        MockERC20 token = new MockERC20("Test", "TST", 18);
+        BalanceSnapshot.Snapshot memory bobBalance = BalanceSnapshot.take(address(bob), address(token));
+
+        // mint(address to, uint256 value)
+        uint256 mintAmount = 1e18;
+        allowanceTarget.executeCall(payable(address(token)), abi.encodeWithSelector(MockERC20.mint.selector, address(bob), mintAmount));
+        bobBalance.assertChange(int256(mintAmount));
+    }
+}

--- a/contracts/test/AllowanceTarget/ExecuteCall.t.sol
+++ b/contracts/test/AllowanceTarget/ExecuteCall.t.sol
@@ -9,7 +9,7 @@ contract TestAllowanceTargetExecuteCall is TestAllowanceTarget {
     // include Snapshot struct from BalanceSnapshot
     using BalanceSnapshot for BalanceSnapshot.Snapshot;
 
-    function testExecuteCallByNotSpender() public {
+    function testCannotExecuteByNotSpender() public {
         vm.prank(bob);
         vm.expectRevert("AllowanceTarget: not the spender");
 
@@ -17,7 +17,7 @@ contract TestAllowanceTargetExecuteCall is TestAllowanceTarget {
         allowanceTarget.executeCall(payable(address(newSpender)), data);
     }
 
-    // usually case
+    // normal case
     function testExecuteCall() public {
         MockERC20 token = new MockERC20("Test", "TST", 18);
         BalanceSnapshot.Snapshot memory bobBalance = BalanceSnapshot.take(address(bob), address(token));

--- a/contracts/test/AllowanceTarget/ExecuteCall.t.sol
+++ b/contracts/test/AllowanceTarget/ExecuteCall.t.sol
@@ -17,7 +17,6 @@ contract TestAllowanceTargetExecuteCall is TestAllowanceTarget {
         allowanceTarget.executeCall(payable(address(newSpender)), data);
     }
 
-    // normal case
     function testExecuteCall() public {
         MockERC20 token = new MockERC20("Test", "TST", 18);
         BalanceSnapshot.Snapshot memory bobBalance = BalanceSnapshot.take(address(bob), address(token));

--- a/contracts/test/AllowanceTarget/ExecuteCall.t.sol
+++ b/contracts/test/AllowanceTarget/ExecuteCall.t.sol
@@ -9,7 +9,7 @@ contract TestAllowanceTargetExecuteCall is TestAllowanceTarget {
     // include Snapshot struct from BalanceSnapshot
     using BalanceSnapshot for BalanceSnapshot.Snapshot;
 
-    function testCannotExecuteByNotSpender() public {
+    function testExecuteCallByNotSpender() public {
         vm.prank(bob);
         vm.expectRevert("AllowanceTarget: not the spender");
 

--- a/contracts/test/AllowanceTarget/SetSpenderWithTimelock.t.sol
+++ b/contracts/test/AllowanceTarget/SetSpenderWithTimelock.t.sol
@@ -4,18 +4,18 @@ pragma solidity 0.7.6;
 import "contracts-test/AllowanceTarget/Setup.t.sol";
 
 contract TestAllowanceTargetSetSpenderWithTimeock is TestAllowanceTarget {
-    function testCannotSetByRandomEOA() public {
+    function testCannotSetSpenderWithTimeockByRandomEOA() public {
         vm.prank(bob);
         vm.expectRevert("AllowanceTarget: not the spender");
         allowanceTarget.setSpenderWithTimelock(newSpender);
     }
 
-    function testCannotSetByInvalidAddress() public {
+    function testCannotSetSpenderWithTimeockByInvalidAddress() public {
         vm.expectRevert("AllowanceTarget: new spender not a contract");
         allowanceTarget.setSpenderWithTimelock(bob);
     }
 
-    function testCannotSetInProgress() public {
+    function testCannotSetSpenderWithTimeockInProgress() public {
         allowanceTarget.setSpenderWithTimelock(newSpender);
         address mySpender = address(new MockStrategy());
         vm.expectRevert("AllowanceTarget: SetSpender in progress");

--- a/contracts/test/AllowanceTarget/SetSpenderWithTimelock.t.sol
+++ b/contracts/test/AllowanceTarget/SetSpenderWithTimelock.t.sol
@@ -22,7 +22,6 @@ contract TestAllowanceTargetSetSpenderWithTimelock is TestAllowanceTarget {
         allowanceTarget.setSpenderWithTimelock(mySpender);
     }
 
-    // normal case
     function testSetSpenderWithTimelock() public {
         allowanceTarget.setSpenderWithTimelock(newSpender);
         assertEq(allowanceTarget.newSpender(), newSpender);

--- a/contracts/test/AllowanceTarget/SetSpenderWithTimelock.t.sol
+++ b/contracts/test/AllowanceTarget/SetSpenderWithTimelock.t.sol
@@ -4,25 +4,25 @@ pragma solidity 0.7.6;
 import "contracts-test/AllowanceTarget/Setup.t.sol";
 
 contract TestAllowanceTargetSetSpenderWithTimeock is TestAllowanceTarget {
-    function testCannotSetSpenderWithTimeockByRandomEOA() public {
+    function testCannotSetByRandomEOA() public {
         vm.prank(bob);
         vm.expectRevert("AllowanceTarget: not the spender");
         allowanceTarget.setSpenderWithTimelock(newSpender);
     }
 
-    function testCannotSetSpenderWithTimeockByInvalidAddress() public {
+    function testCannotSetByInvalidAddress() public {
         vm.expectRevert("AllowanceTarget: new spender not a contract");
         allowanceTarget.setSpenderWithTimelock(bob);
     }
 
-    function testCannotSetSpenderWithTimeockInProgress() public {
+    function testCannotSetInProgress() public {
         allowanceTarget.setSpenderWithTimelock(newSpender);
         address mySpender = address(new MockStrategy());
         vm.expectRevert("AllowanceTarget: SetSpender in progress");
         allowanceTarget.setSpenderWithTimelock(mySpender);
     }
 
-    // usually case
+    // normal case
     function testSetSpenderWithTimeock() public {
         allowanceTarget.setSpenderWithTimelock(newSpender);
         assertEq(allowanceTarget.newSpender(), newSpender);

--- a/contracts/test/AllowanceTarget/SetSpenderWithTimelock.t.sol
+++ b/contracts/test/AllowanceTarget/SetSpenderWithTimelock.t.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.7.6;
+
+import "contracts-test/AllowanceTarget/Setup.t.sol";
+
+contract TestAllowanceTargetSetSpenderWithTimeock is TestAllowanceTarget {
+    function testCannotSetByRandomEOA() public {
+        vm.prank(bob);
+        vm.expectRevert("AllowanceTarget: not the spender");
+        allowanceTarget.setSpenderWithTimelock(newSpender);
+    }
+
+    function testCannotSetByInvalidAddress() public {
+        vm.expectRevert("AllowanceTarget: new spender not a contract");
+        allowanceTarget.setSpenderWithTimelock(bob);
+    }
+
+    function testCannotSetInProgress() public {
+        allowanceTarget.setSpenderWithTimelock(newSpender);
+        address mySpender = address(new MockStrategy());
+        vm.expectRevert("AllowanceTarget: SetSpender in progress");
+        allowanceTarget.setSpenderWithTimelock(mySpender);
+    }
+
+    // usually case
+    function testSetSpenderWithTimeock() public {
+        allowanceTarget.setSpenderWithTimelock(newSpender);
+        assertEq(allowanceTarget.newSpender(), newSpender);
+        assertEq(allowanceTarget.timelockExpirationTime(), block.timestamp + 1 days);
+    }
+}

--- a/contracts/test/AllowanceTarget/SetSpenderWithTimelock.t.sol
+++ b/contracts/test/AllowanceTarget/SetSpenderWithTimelock.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.7.6;
 
 import "contracts-test/AllowanceTarget/Setup.t.sol";
 
-contract TestAllowanceTargetSetSpenderWithTimeock is TestAllowanceTarget {
+contract TestAllowanceTargetSetSpenderWithTimelock is TestAllowanceTarget {
     function testCannotSetByRandomEOA() public {
         vm.prank(bob);
         vm.expectRevert("AllowanceTarget: not the spender");
@@ -23,7 +23,7 @@ contract TestAllowanceTargetSetSpenderWithTimeock is TestAllowanceTarget {
     }
 
     // normal case
-    function testSetSpenderWithTimeock() public {
+    function testSetSpenderWithTimelock() public {
         allowanceTarget.setSpenderWithTimelock(newSpender);
         assertEq(allowanceTarget.newSpender(), newSpender);
         assertEq(allowanceTarget.timelockExpirationTime(), block.timestamp + 1 days);

--- a/contracts/test/AllowanceTarget/Setup.t.sol
+++ b/contracts/test/AllowanceTarget/Setup.t.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.7.6;
+
+import "forge-std/Test.sol";
+import "contracts/AllowanceTarget.sol";
+import "contracts-test/mocks/MockStrategy.sol";
+
+contract TestAllowanceTarget is Test {
+    address newSpender = address(new MockStrategy());
+    address bob = address(0x133701);
+
+    AllowanceTarget allowanceTarget;
+
+    // effectively a "beforeEach" block
+    function setUp() public virtual {
+        // Setup
+        allowanceTarget = new AllowanceTarget(address(this));
+
+        // Label addresses for easier debugging
+        vm.label(address(this), "TestingContract");
+        vm.label(address(allowanceTarget), "AllowanceTarget");
+    }
+}

--- a/contracts/test/AllowanceTarget/Teardown.t.sol
+++ b/contracts/test/AllowanceTarget/Teardown.t.sol
@@ -14,7 +14,6 @@ contract TestAllowanceTargetTeardown is TestAllowanceTarget {
         allowanceTarget.teardown();
     }
 
-    // normal case
     function testTeardown() public {
         BalanceSnapshot.Snapshot memory beneficiary = BalanceSnapshot.take(address(this), ETH_ADDRESS);
         uint256 heritage = 10 ether;

--- a/contracts/test/AllowanceTarget/Teardown.t.sol
+++ b/contracts/test/AllowanceTarget/Teardown.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.7.6;
+
+import "contracts-test/AllowanceTarget/Setup.t.sol";
+import "contracts-test/utils/BalanceSnapshot.sol";
+
+contract TestAllowanceTargetTeardown is TestAllowanceTarget {
+    // include Snapshot struct from BalanceSnapshot
+    using BalanceSnapshot for BalanceSnapshot.Snapshot;
+
+    function testCannotTeardownByNotSpender() public {
+        vm.prank(bob);
+        vm.expectRevert("AllowanceTarget: not the spender");
+        allowanceTarget.teardown();
+    }
+
+    // usually case
+    function testTeardown() public {
+        BalanceSnapshot.Snapshot memory beneficiary = BalanceSnapshot.take(address(this), ETH_ADDRESS);
+        uint256 heritage = 10 ether;
+        deal(address(allowanceTarget), heritage);
+        allowanceTarget.teardown();
+        beneficiary.assertChange(int256(heritage));
+    }
+}

--- a/contracts/test/AllowanceTarget/Teardown.t.sol
+++ b/contracts/test/AllowanceTarget/Teardown.t.sol
@@ -14,7 +14,7 @@ contract TestAllowanceTargetTeardown is TestAllowanceTarget {
         allowanceTarget.teardown();
     }
 
-    // usually case
+    // normal case
     function testTeardown() public {
         BalanceSnapshot.Snapshot memory beneficiary = BalanceSnapshot.take(address(this), ETH_ADDRESS);
         uint256 heritage = 10 ether;


### PR DESCRIPTION
In order to make the AllowanceTarget contract test files more readable, change these test files into a hierarchical directory.

These test contracts conform to the following specifications:
1) One file, one contract.
2) Test contracts are named with upper camel case.
3) Test functions are named with lower camel case.
4) Minimal import principle: do not import unused libraries.

Please use the following command to test:
```bash
forge test -vvv --force --match-path 'contracts/test/AllowanceTarget/*.t.sol'
```

The following is the test execution result:
```
Running 2 tests for contracts/test/AllowanceTarget/Constructor.t.sol:TestAllowanceTargetConstructor
[PASS] testCannotDeployByZeroAddress() (gas: 41031)
[PASS] testConstructor() (gas: 7650)
Test result: ok. 2 passed; 0 failed; finished in 1.20ms

Running 3 tests for contracts/test/AllowanceTarget/CompleteSetSpender.t.sol:TestAllowanceTargetCompleteSetSpender
[PASS] testCannotCompleteBeforeSet() (gas: 10620)
[PASS] testCannotCompleteTooEarly() (gas: 60817)
[PASS] testCompleteSetSpender() (gas: 48614)
Test result: ok. 3 passed; 0 failed; finished in 1.95ms

Running 2 tests for contracts/test/AllowanceTarget/Teardown.t.sol:TestAllowanceTargetTeardown
[PASS] testCannotTeardownByNotSpender() (gas: 13059)
[PASS] testTeardown() (gas: 14054)
Test result: ok. 2 passed; 0 failed; finished in 1.87ms

Running 2 tests for contracts/test/AllowanceTarget/ExecuteCall.t.sol:TestAllowanceTargetExecuteCall
[PASS] testCannotExecuteByNotSpender() (gas: 16015)
[PASS] testExecuteCall() (gas: 832810)
Test result: ok. 2 passed; 0 failed; finished in 2.11ms

Running 4 tests for contracts/test/AllowanceTarget/SetSpenderWithTimelock.t.sol:TestAllowanceTargetSetSpenderWithTimeock
[PASS] testCannotSetByInvalidAddress() (gas: 15503)
[PASS] testCannotSetByRandomEOA() (gas: 15318)
[PASS] testCannotSetInProgress() (gas: 141333)
[PASS] testSetSpenderWithTimeock() (gas: 58853)
Test result: ok. 4 passed; 0 failed; finished in 2.05ms
```

Thanks a lot!