### PR TITLE
Update signature validator sig length check

### DIFF
--- a/contracts/test/forkMainnet/AMMWrapperWithPath.t.sol
+++ b/contracts/test/forkMainnet/AMMWrapperWithPath.t.sol
@@ -8,6 +8,7 @@ import "contracts/interfaces/IPermanentStorage.sol";
 import "contracts/interfaces/ISpender.sol";
 import "contracts/interfaces/IBalancerV2Vault.sol";
 import "contracts/utils/AMMLibEIP712.sol";
+import "contracts/utils/SignatureValidator.sol";
 import "contracts-test/utils/AMMUtil.sol";
 import "contracts-test/utils/BalanceSnapshot.sol";
 import "contracts-test/utils/StrategySharedSetup.sol";
@@ -160,6 +161,24 @@ contract AMMWrapperWithPathTest is StrategySharedSetup {
         order.makerAssetAddr = ETH_ADDRESS;
         order.makerAssetAmount = 0.001 ether;
         bytes memory sig = _signTrade(userPrivateKey, order);
+        bytes memory payload = _genTradePayload(order, feeFactor, sig, bytes(""), new address[](0));
+
+        BalanceSnapshot.Snapshot memory userTakerAsset = BalanceSnapshot.take(user, order.takerAssetAddr);
+        BalanceSnapshot.Snapshot memory userMakerAsset = BalanceSnapshot.take(user, order.makerAssetAddr);
+
+        userProxy.toAMM(payload);
+
+        userTakerAsset.assertChange(-int256(order.takerAssetAmount));
+        userMakerAsset.assertChangeGt(int256(order.makerAssetAmount));
+    }
+
+    function testTradeSushiswap_SingleHop_WithOldEIP712Method() public {
+        uint256 feeFactor = 0;
+        AMMLibEIP712.Order memory order = DEFAULT_ORDER;
+        order.makerAddr = SUSHISWAP_ADDRESS;
+        order.makerAssetAddr = ETH_ADDRESS;
+        order.makerAssetAmount = 0.001 ether;
+        bytes memory sig = _signTradeWithOldEIP712Method(userPrivateKey, order);
         bytes memory payload = _genTradePayload(order, feeFactor, sig, bytes(""), new address[](0));
 
         BalanceSnapshot.Snapshot memory userTakerAsset = BalanceSnapshot.take(user, order.takerAssetAddr);
@@ -406,7 +425,14 @@ contract AMMWrapperWithPathTest is StrategySharedSetup {
         bytes32 orderHash = AMMLibEIP712._getOrderHash(order);
         bytes32 EIP712SignDigest = _getEIP712Hash(orderHash);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, EIP712SignDigest);
-        sig = abi.encodePacked(r, s, v, bytes32(0), uint8(2));
+        sig = abi.encodePacked(r, s, v, uint8(SignatureValidator.SignatureType.EIP712));
+    }
+
+    function _signTradeWithOldEIP712Method(uint256 privateKey, AMMLibEIP712.Order memory order) internal returns (bytes memory sig) {
+        bytes32 orderHash = AMMLibEIP712._getOrderHash(order);
+        bytes32 EIP712SignDigest = _getEIP712Hash(orderHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, EIP712SignDigest);
+        sig = abi.encodePacked(r, s, v, bytes32(0), uint8(SignatureValidator.SignatureType.EIP712));
     }
 
     function _genTradePayload(

--- a/contracts/utils/SignatureValidator.sol
+++ b/contracts/utils/SignatureValidator.sol
@@ -93,7 +93,7 @@ contract SignatureValidator {
 
             // Signature using EIP712
         } else if (signatureType == SignatureType.EIP712) {
-            require(_sig.length == 97, "SignatureValidator#isValidSignature: length 97 required");
+            require(_sig.length == 65 || _sig.length == 97, "SignatureValidator#isValidSignature: length 65 or 97 required");
             r = _sig.readBytes32(0);
             s = _sig.readBytes32(32);
             v = uint8(_sig[64]);
@@ -103,7 +103,7 @@ contract SignatureValidator {
 
             // Signed using web3.eth_sign() or Ethers wallet.signMessage()
         } else if (signatureType == SignatureType.EthSign) {
-            require(_sig.length == 97, "SignatureValidator#isValidSignature: length 97 required");
+            require(_sig.length == 65 || _sig.length == 97, "SignatureValidator#isValidSignature: length 65 or 97 required");
             r = _sig.readBytes32(0);
             s = _sig.readBytes32(32);
             v = uint8(_sig[64]);


### PR DESCRIPTION
- Allow sig length 65 in EIP712/EthSign sig type in SignatureValidator
- Update tests to use new signing method (sig length 65)
    - Add test for old signing method (sig length 97)