### PR TITLE
Add `setMaxLockDuration` function to `add-veLON-impplementation`

### DIFF
--- a/contracts/interfaces/IveLON.sol
+++ b/contracts/interfaces/IveLON.sol
@@ -14,13 +14,13 @@ interface IveLON is IERC721, IERC721Metadata {
     }
 
     struct LockedBalance {
-        int128 amount; // FIXME use uint256?
+        uint256 amount;
         uint256 end;
     }
 
     struct Point {
-        int128 bias;
-        int128 slope; // # -dweight / dt
+        int256 bias;
+        int256 slope; // # -dweight / dt
         uint256 ts;
         uint256 blk;
     }

--- a/contracts/interfaces/IveLON.sol
+++ b/contracts/interfaces/IveLON.sol
@@ -31,6 +31,8 @@ interface IveLON is IERC721, IERC721Metadata {
     // TODO need this event?
     // event Supply(uint256 prevSupply, uint256 supply);?
 
+    function setMaxLockDuration(uint256 _maxLockDuration) external;
+
     function unlockTime(uint256 _tokenId) external view returns (uint256);
 
     function createLock(uint256 _value, uint256 _lockDuration) external returns (uint256);

--- a/contracts/veLON.sol
+++ b/contracts/veLON.sol
@@ -28,7 +28,7 @@ contract veLON is IveLON, ERC721, Ownable, ReentrancyGuard {
     mapping(uint256 => Point[1000000000]) public userPointHistory; // user -> Point[user_epoch]
     mapping(uint256 => LockedBalance) public locked; // tokenId -> locked balance
     mapping(uint256 => uint256) public userPointEpoch; // tokenId -> epoch
-    mapping(uint256 => int256) public slope_changes; // time -> signed slope change
+    mapping(uint256 => int256) public slopeChanges; // time -> signed slope change
 
     /// @dev Current count of token
     uint256 internal tokenId;
@@ -274,12 +274,12 @@ contract veLON is IveLON, ERC721, Ownable, ReentrancyGuard {
             // Read values of scheduled changes in the slope
             // _oldLocked.end can be in the past and in the future
             // _newLocked.end can ONLY by in the FUTURE unless everything expired: than zeros
-            dSlopeOld = slope_changes[_oldLocked.end];
+            dSlopeOld = slopeChanges[_oldLocked.end];
             if (_newLocked.end != 0) {
                 if (_newLocked.end == _oldLocked.end) {
                     dSlopeNew = dSlopeOld;
                 } else {
-                    dSlopeNew = slope_changes[_newLocked.end];
+                    dSlopeNew = slopeChanges[_newLocked.end];
                 }
             }
         }
@@ -314,7 +314,7 @@ contract veLON is IveLON, ERC721, Ownable, ReentrancyGuard {
                 if (timeEnd > block.timestamp) {
                     timeEnd = block.timestamp;
                 } else {
-                    dSlope = slope_changes[timeEnd];
+                    dSlope = slopeChanges[timeEnd];
                 }
 
                 // update slope and bias
@@ -375,13 +375,13 @@ contract veLON is IveLON, ERC721, Ownable, ReentrancyGuard {
                 if (_newLocked.end == _oldLocked.end) {
                     dSlopeOld -= pointNew.slope; // It was a new deposit, not extension
                 }
-                slope_changes[_oldLocked.end] = dSlopeOld;
+                slopeChanges[_oldLocked.end] = dSlopeOld;
             }
 
             if (_newLocked.end > block.timestamp) {
                 if (_newLocked.end > _oldLocked.end) {
                     dSlopeNew -= pointNew.slope; // old slope disappeared at this point
-                    slope_changes[_newLocked.end] = dSlopeNew;
+                    slopeChanges[_newLocked.end] = dSlopeNew;
                 }
                 // else: we recorded it already in dSlopeOld
             }

--- a/contracts/veLON.sol
+++ b/contracts/veLON.sol
@@ -91,7 +91,7 @@ contract veLON is IveLON, ERC721, Ownable, ReentrancyGuard {
         epoch = epoch.add(1);
         poolPointHistory[epoch] = Point({ bias: globalBias, slope: globalSlope, ts: block.timestamp, blk: block.number });
 
-        // updatee the maxLockDuration
+        // update the maxLockDuration
         maxLockDuration = _maxLockDuration;
     }
 

--- a/contracts/veLON.sol
+++ b/contracts/veLON.sol
@@ -80,8 +80,8 @@ contract veLON is IveLON, ERC721, Ownable, ReentrancyGuard {
             userPointHistory[_tokenId][userEpoch] = pointNew;
 
             // update slope_changes
-            slope_changes[oldLocked.end] += pointOld.slope;
-            slope_changes[newLocked.end] += pointNew.slope;
+            slopeChanges[oldLocked.end] += pointOld.slope;
+            slopeChanges[newLocked.end] += pointNew.slope;
 
             globalSlope += pointNew.slope;
             globalBias += pointNew.bias;

--- a/contracts/veLON.sol
+++ b/contracts/veLON.sol
@@ -13,6 +13,7 @@ import "./Ownable.sol";
 
 contract veLON is IveLON, ERC721, Ownable, ReentrancyGuard {
     using SafeMath for uint256;
+    using SafeMath for int256;
 
     uint256 private constant WEEK = 1 weeks;
     uint256 public constant PENALTY_RATE_PRECISION = 10000;
@@ -40,6 +41,56 @@ contract veLON is IveLON, ERC721, Ownable, ReentrancyGuard {
 
         poolPointHistory[0].blk = block.number;
         poolPointHistory[0].ts = block.timestamp;
+    }
+
+    /// @notice Update the `maxLockDuration`.
+    /// @param _maxLockDuration new number of seconds for `maxLockDuration`.
+    function setMaxLockDuration(uint256 _maxLockDuration) external onlyOwner {
+        // flush the global voting power change into storage first
+        _checkpoint(0, LockedBalance(0, 0), LockedBalance(0, 0));
+
+        uint256 constant maxEndTime = block.timestamp.add(_maxLockDuration).div(WEEK).mul(WEEK);
+        int256 globalSlope;
+        int256 globalBias;
+        // update every NFT's stored states and calculate global states
+        for (uint256 _tokenId = 0; _tokenId <= tokenId; _tokenId++) { 
+            // skip NFTs that have been burned
+            if (ownerOf(_tokenId) == address(0)) {
+                continue;
+            }
+            // skip expired NFTs
+            if (locked[_tokenId].end < block.timestamp) {
+                continue;
+            }
+
+            uint256 userEpoch = userPointEpoch[_tokenId];
+            LockedBalance memory oldLocked = locked[_tokenId];
+            LockedBalance memory newLocked = locked[_tokenId];
+            Point memory pointOld = userPointHistory[_tokenId][userEpoch];
+            Point memory pointNew = Point({ bias: 0, slope: 0, ts: block.timestamp, blk: block.number });
+            if (newLocked.end > maxEndTime) {
+                newLocked.end = maxEndTime;
+            }
+            pointNew.slope = newLocked.amount.div(_maxLockDuration);
+            int256 duration = int256(newLocked.end.sub(block.timestamp));
+            pointNew.bias = pointNew.slope.mul(duration);
+
+            // update the latest user epoch and user point
+            userEpoch = userEpoch.add(1);
+            userPointEpoch[_tokenId] = userEpoch;
+            userPointHistory[_tokenId][userEpoch] = pointNew;
+
+            // update slope_changes
+            slope_changes[oldLocked.end] = slope_changes[oldLocked.end].add(pointOld.slope);
+            slope_changes[newLocked.end] = slope_changes[newLocked.end].sub(pointNew.slope);
+
+            globalSlope = globalSlope.add(pointNew.slope);
+            globalBias = globalBias.add(pointNew.bias);
+        }
+
+        // update global point
+        epoch = epoch.add(1);
+        poolPointHistory[epoch] = Point( { bias: globalBias, slope: globalSlope, ts: block.timestamp, blk: block.number } );
     }
 
     /// @notice Get timestamp when `_tokenId`'s lock finishes

--- a/contracts/veLON.sol
+++ b/contracts/veLON.sol
@@ -90,6 +90,9 @@ contract veLON is IveLON, ERC721, Ownable, ReentrancyGuard {
         // update global point
         epoch = epoch.add(1);
         poolPointHistory[epoch] = Point({ bias: globalBias, slope: globalSlope, ts: block.timestamp, blk: block.number });
+
+        // updatee the maxLockDuration
+        maxLockDuration = _maxLockDuration;
     }
 
     /// @notice Get timestamp when `_tokenId`'s lock finishes


### PR DESCRIPTION
Add `setMaxLockDuration` function to `add-veLON-impplementation` branch.

Given the correctness and fairness, the code guarantees that if `old_power_A > old_power_B`, then after updating the `maxLockDuration` we have `new_power_A >= new_power_B`.

Code details are as follows:

- if NFT's `lock.end > maxEndTime`, we set the `lock.end = maxEndTime`. Then we update NFT's slope and bias
- if NFT's `lock.end <= maxEndTime`, we update NFT's slope and bias directly

After updating every NFT's end, slope, and bias, we will update the global slope and bias.