### PR TITLE
fix multicall result data

### DIFF
--- a/contracts/UserProxy.sol
+++ b/contracts/UserProxy.sol
@@ -145,14 +145,11 @@ contract UserProxy is Multicall {
     function toAMM(bytes calldata _payload) external payable {
         require(isAMMEnabled(), "UserProxy: AMM is disabled");
 
-        (bool callSucceed, ) = ammWrapperAddr().call{ value: msg.value }(_payload);
-        if (callSucceed == false) {
-            // Get the error message returned
+        (bool callSucceed, bytes memory result) = ammWrapperAddr().call{ value: msg.value }(_payload);
+        if (!callSucceed) {
+            // revert with message from last call
             assembly {
-                let ptr := mload(0x40)
-                let size := returndatasize()
-                returndatacopy(ptr, 0, size)
-                revert(ptr, size)
+                revert(add(result, 0x20), returndatasize())
             }
         }
     }
@@ -164,14 +161,11 @@ contract UserProxy is Multicall {
         require(isRFQEnabled(), "UserProxy: RFQ is disabled");
         require(msg.sender == tx.origin, "UserProxy: only EOA");
 
-        (bool callSucceed, ) = rfqAddr().call{ value: msg.value }(_payload);
-        if (callSucceed == false) {
-            // Get the error message returned
+        (bool callSucceed, bytes memory result) = rfqAddr().call{ value: msg.value }(_payload);
+        if (!callSucceed) {
+            // revert with message from last call
             assembly {
-                let ptr := mload(0x40)
-                let size := returndatasize()
-                returndatacopy(ptr, 0, size)
-                revert(ptr, size)
+                revert(add(result, 0x20), returndatasize())
             }
         }
     }
@@ -180,14 +174,11 @@ contract UserProxy is Multicall {
         require(isLimitOrderEnabled(), "UserProxy: Limit Order is disabled");
         require(msg.sender == tx.origin, "UserProxy: only EOA");
 
-        (bool callSucceed, ) = limitOrderAddr().call(_payload);
-        if (callSucceed == false) {
-            // Get the error message returned
+        (bool callSucceed, bytes memory result) = limitOrderAddr().call(_payload);
+        if (!callSucceed) {
+            // revert with message from last call
             assembly {
-                let ptr := mload(0x40)
-                let size := returndatasize()
-                returndatacopy(ptr, 0, size)
-                revert(ptr, size)
+                revert(add(result, 0x20), returndatasize())
             }
         }
     }

--- a/contracts/UserProxy.sol
+++ b/contracts/UserProxy.sol
@@ -145,11 +145,14 @@ contract UserProxy is Multicall {
     function toAMM(bytes calldata _payload) external payable {
         require(isAMMEnabled(), "UserProxy: AMM is disabled");
 
-        (bool callSucceed, bytes memory result) = ammWrapperAddr().call{ value: msg.value }(_payload);
+        (bool callSucceed, ) = ammWrapperAddr().call{ value: msg.value }(_payload);
         if (!callSucceed) {
-            // revert with message from last call
+            // revert with data from last call
             assembly {
-                revert(add(result, 0x20), returndatasize())
+                let ptr := mload(0x40)
+                let size := returndatasize()
+                returndatacopy(ptr, 0, size)
+                revert(ptr, size)
             }
         }
     }
@@ -161,24 +164,33 @@ contract UserProxy is Multicall {
         require(isRFQEnabled(), "UserProxy: RFQ is disabled");
         require(msg.sender == tx.origin, "UserProxy: only EOA");
 
-        (bool callSucceed, bytes memory result) = rfqAddr().call{ value: msg.value }(_payload);
+        (bool callSucceed, ) = rfqAddr().call{ value: msg.value }(_payload);
         if (!callSucceed) {
-            // revert with message from last call
+            // revert with data from last call
             assembly {
-                revert(add(result, 0x20), returndatasize())
+                let ptr := mload(0x40)
+                let size := returndatasize()
+                returndatacopy(ptr, 0, size)
+                revert(ptr, size)
             }
         }
     }
 
+    /**
+     * @dev proxy the call to Limit Order
+     */
     function toLimitOrder(bytes calldata _payload) external {
         require(isLimitOrderEnabled(), "UserProxy: Limit Order is disabled");
         require(msg.sender == tx.origin, "UserProxy: only EOA");
 
-        (bool callSucceed, bytes memory result) = limitOrderAddr().call(_payload);
+        (bool callSucceed, ) = limitOrderAddr().call(_payload);
         if (!callSucceed) {
-            // revert with message from last call
+            // revert with data from last call
             assembly {
-                revert(add(result, 0x20), returndatasize())
+                let ptr := mload(0x40)
+                let size := returndatasize()
+                returndatacopy(ptr, 0, size)
+                revert(ptr, size)
             }
         }
     }

--- a/contracts/test/UserProxy.t.sol
+++ b/contracts/test/UserProxy.t.sol
@@ -8,6 +8,7 @@ import "contracts-test/mocks/MockStrategy.sol";
 
 contract UserProxyTest is Test {
     event TearDownAllowanceTarget(uint256 tearDownTimeStamp);
+    event MulticallFailure(uint256 index, string reason);
 
     address user = address(0x133701);
     address relayer = address(0x133702);
@@ -233,27 +234,44 @@ contract UserProxyTest is Test {
      *                Test: multicall                  *
      ***************************************************/
 
-    function testMulticallAMMandRFQ() public {
-        userProxy.upgradeAMMWrapper(address(strategy), true);
-        userProxy.upgradeRFQ(address(strategy), false);
+    function testMulticallNoRevertOnFail() public {
+        MockStrategy mockAMM = new MockStrategy();
+        mockAMM.setShouldFail(false);
+        userProxy.upgradeAMMWrapper(address(mockAMM), true);
+        MockStrategy mockRFQ = new MockStrategy();
+        mockRFQ.setShouldFail(true);
+        userProxy.upgradeRFQ(address(mockRFQ), true);
 
         bytes[] memory data = new bytes[](2);
-        data[0] = abi.encodeWithSelector(UserProxy.toAMM.selector, MockStrategy.execute.selector);
-        data[1] = abi.encodeWithSelector(UserProxy.toRFQ.selector, MockStrategy.execute.selector);
+        bytes memory strategyData = abi.encodeWithSelector(MockStrategy.execute.selector);
+        data[0] = abi.encodeWithSelector(UserProxy.toAMM.selector, strategyData);
+        data[1] = abi.encodeWithSelector(UserProxy.toRFQ.selector, strategyData);
+
+        // MulticallFailure event should be emitted to indicate failures
+        vm.expectEmit(true, true, true, true);
+        emit MulticallFailure(1, "Execution failed");
+
+        // tx should succeed even one of subcall failed (RFQ)
         vm.prank(relayer, relayer);
-        // should succeed even RFQ is disabled
         userProxy.multicall(data, false);
     }
 
     function testMulticallRevertOnFail() public {
-        userProxy.upgradeAMMWrapper(address(strategy), true);
-        userProxy.upgradeRFQ(address(strategy), false);
+        MockStrategy mockAMM = new MockStrategy();
+        mockAMM.setShouldFail(false);
+        userProxy.upgradeAMMWrapper(address(mockAMM), true);
+        MockStrategy mockRFQ = new MockStrategy();
+        mockRFQ.setShouldFail(true);
+        userProxy.upgradeRFQ(address(mockRFQ), true);
 
         bytes[] memory data = new bytes[](2);
-        data[0] = abi.encodeWithSelector(UserProxy.toAMM.selector, MockStrategy.execute.selector);
-        data[1] = abi.encodeWithSelector(UserProxy.toRFQ.selector, MockStrategy.execute.selector);
+        bytes memory strategyData = abi.encodeWithSelector(MockStrategy.execute.selector);
+        data[0] = abi.encodeWithSelector(UserProxy.toAMM.selector, strategyData);
+        data[1] = abi.encodeWithSelector(UserProxy.toRFQ.selector, strategyData);
+
+        // Should revert with message from MockStrategy
+        vm.expectRevert("Execution failed");
         vm.prank(relayer, relayer);
-        vm.expectRevert("Delegatecall failed");
         userProxy.multicall(data, true);
     }
 }

--- a/contracts/test/UserProxy.t.sol
+++ b/contracts/test/UserProxy.t.sol
@@ -253,7 +253,14 @@ contract UserProxyTest is Test {
 
         // tx should succeed even one of subcall failed (RFQ)
         vm.prank(relayer, relayer);
-        userProxy.multicall(data, false);
+
+        (bool[] memory successes, bytes[] memory results) = userProxy.multicall(data, false);
+        bytes[] memory expectedResult = new bytes[](2);
+        expectedResult[1] = abi.encodeWithSignature("Error(string)", "Execution failed");
+        assertEq(successes[0], true);
+        assertEq0(results[0], expectedResult[0]);
+        assertEq(successes[1], false);
+        assertEq0(results[1], expectedResult[1]);
     }
 
     function testMulticallRevertOnFail() public {

--- a/contracts/utils/Multicall.sol
+++ b/contracts/utils/Multicall.sol
@@ -11,6 +11,8 @@ abstract contract Multicall is IMulticall {
         results = new bytes[](data.length);
         for (uint256 i = 0; i < data.length; i++) {
             (bool success, bytes memory result) = address(this).delegatecall(data[i]);
+            successes[i] = success;
+            results[i] = result;
 
             if (!success) {
                 // Get failed reason
@@ -29,8 +31,6 @@ abstract contract Multicall is IMulticall {
                 }
                 emit MulticallFailure(i, revertReason);
             }
-            successes[i] = success;
-            results[i] = result;
         }
     }
 }


### PR DESCRIPTION
If one of subcall is reverted during multicall process, the `result` offset will be changed in order to get the revert message. Therefore, copying the `success` and `result` into array should be done before changing the offset.