### PR TITLE
Adjust AMM actual fee calculation

### DIFF
--- a/contracts/test/forkMainnet/AMMWrapper/CollectFee.t.sol
+++ b/contracts/test/forkMainnet/AMMWrapper/CollectFee.t.sol
@@ -27,10 +27,11 @@ contract TestAMMWrapperCollectFee is TestAMMWrapper {
         uint256 feeFactor = 100;
         AMMLibEIP712.Order memory order = DEFAULT_ORDER;
         uint256 expectedOutAmount = ammQuoter.getMakerOutAmount(order.makerAddr, order.takerAssetAddr, order.makerAssetAddr, order.takerAssetAmount);
+        uint256 actualFee = (expectedOutAmount * feeFactor) / LibConstant.BPS_MAX;
+        uint256 settleAmount = expectedOutAmount - actualFee;
         // order should align with user's perspective
         // therefore it should deduct fee from expectedOutAmount as the makerAssetAmount in order
-        uint256 fee = (expectedOutAmount * feeFactor) / BPS_MAX;
-        order.makerAssetAmount = expectedOutAmount - fee;
+        order.makerAssetAmount = settleAmount;
         bytes memory sig = _signTrade(userPrivateKey, order);
         bytes memory payload = _genTradePayload(order, feeFactor, sig);
 
@@ -39,7 +40,7 @@ contract TestAMMWrapperCollectFee is TestAMMWrapper {
         vm.prank(relayer, relayer);
         userProxy.toAMM(payload);
 
-        feeCollectorMakerAsset.assertChange(int256(fee));
+        feeCollectorMakerAsset.assertChange(int256(actualFee));
     }
 
     function testCollectFeeWithWETH() public {
@@ -47,10 +48,11 @@ contract TestAMMWrapperCollectFee is TestAMMWrapper {
         AMMLibEIP712.Order memory order = DEFAULT_ORDER;
         order.makerAssetAddr = ETH_ADDRESS;
         uint256 expectedOutAmount = ammQuoter.getMakerOutAmount(order.makerAddr, order.takerAssetAddr, order.makerAssetAddr, order.takerAssetAmount);
+        uint256 actualFee = (expectedOutAmount * feeFactor) / LibConstant.BPS_MAX;
+        uint256 settleAmount = expectedOutAmount - actualFee;
         // order should align with user's perspective
         // therefore it should deduct fee from expectedOutAmount as the makerAssetAmount in order
-        uint256 fee = (expectedOutAmount * feeFactor) / BPS_MAX;
-        order.makerAssetAmount = expectedOutAmount - fee;
+        order.makerAssetAmount = settleAmount;
         bytes memory sig = _signTrade(userPrivateKey, order);
         bytes memory payload = _genTradePayload(order, feeFactor, sig);
 
@@ -60,7 +62,7 @@ contract TestAMMWrapperCollectFee is TestAMMWrapper {
         vm.prank(relayer, relayer);
         userProxy.toAMM(payload);
 
-        feeCollectorMakerAsset.assertChange(int256(fee));
+        feeCollectorMakerAsset.assertChange(int256(actualFee));
     }
 
     function testCollectFeeWithETH() public {
@@ -68,13 +70,14 @@ contract TestAMMWrapperCollectFee is TestAMMWrapper {
         AMMLibEIP712.Order memory order = DEFAULT_ORDER;
         order.makerAddr = CURVE_ANKRETH_POOL_ADDRESS;
         order.takerAssetAddr = ANKRETH_ADDRESS;
-        order.takerAssetAmount = 0.01 ether;
+        order.takerAssetAmount = 1 ether;
         order.makerAssetAddr = ETH_ADDRESS;
         uint256 expectedOutAmount = ammQuoter.getMakerOutAmount(order.makerAddr, order.takerAssetAddr, order.makerAssetAddr, order.takerAssetAmount);
+        uint256 actualFee = (expectedOutAmount * feeFactor) / LibConstant.BPS_MAX;
+        uint256 settleAmount = expectedOutAmount - actualFee;
         // order should align with user's perspective
         // therefore it should deduct fee from expectedOutAmount as the makerAssetAmount in order
-        uint256 fee = (expectedOutAmount * feeFactor) / BPS_MAX;
-        order.makerAssetAmount = expectedOutAmount - fee;
+        order.makerAssetAmount = settleAmount;
         bytes memory sig = _signTrade(userPrivateKey, order);
         bytes memory payload = _genTradePayload(order, feeFactor, sig);
 
@@ -84,19 +87,25 @@ contract TestAMMWrapperCollectFee is TestAMMWrapper {
         vm.prank(relayer, relayer);
         userProxy.toAMM(payload);
 
-        feeCollectorMakerAsset.assertChange(int256(fee));
+        feeCollectorMakerAsset.assertChange(int256(actualFee));
     }
 
     function testFeeFactorOverwrittenWithDefault() public {
         // set local feeFactor higher than default one to avoid insufficient output from AMM
-        uint256 feeFactor = ammWrapper.defaultFeeFactor() + 1000;
+        uint256 feeFactor = DEFAULT_FEE_FACTOR + 1000;
         AMMLibEIP712.Order memory order = DEFAULT_ORDER;
         uint256 expectedOutAmount = ammQuoter.getMakerOutAmount(order.makerAddr, order.takerAssetAddr, order.makerAssetAddr, order.takerAssetAmount);
-        // set makerAssetAmount = expectedOutAmount - expectedFee
-        order.makerAssetAmount = expectedOutAmount - ((expectedOutAmount * feeFactor) / BPS_MAX);
+
+        // try to avoid stack too deep
+        {
+            uint256 expectedFee = (expectedOutAmount * feeFactor) / LibConstant.BPS_MAX;
+            // calculate order.makerAssetAmount using local fee factor, expect to receive more since default fee factor is smaller
+            order.makerAssetAmount = expectedOutAmount - expectedFee;
+        }
+
         bytes memory sig = _signTrade(userPrivateKey, order);
         bytes memory payload = _genTradePayload(order, feeFactor, sig);
-        uint256 actualFee = (expectedOutAmount * ammWrapper.defaultFeeFactor()) / BPS_MAX;
+        uint256 actualFee = (expectedOutAmount * DEFAULT_FEE_FACTOR) / LibConstant.BPS_MAX;
 
         BalanceSnapshot.Snapshot memory feeCollectorMakerAsset = BalanceSnapshot.take(feeCollector, order.makerAssetAddr);
 
@@ -113,7 +122,7 @@ contract TestAMMWrapperCollectFee is TestAMMWrapper {
             order.makerAssetAmount,
             order.receiverAddr,
             expectedOutAmount - actualFee,
-            ammWrapper.defaultFeeFactor() // default fee factor will be applied
+            DEFAULT_FEE_FACTOR // default fee factor will be applied
         );
         userProxy.toAMM(payload);
 

--- a/contracts/test/forkMainnet/AMMWrapper/Setup.t.sol
+++ b/contracts/test/forkMainnet/AMMWrapper/Setup.t.sol
@@ -27,7 +27,7 @@ contract TestAMMWrapper is StrategySharedSetup {
     IERC20 ankreth = IERC20(ANKRETH_ADDRESS);
     IERC20[] tokens = [weth, usdt, dai, ankreth];
 
-    uint16 DEFAULT_FEE_FACTOR = 1000;
+    uint16 DEFAULT_FEE_FACTOR = 500;
     uint256 DEADLINE = block.timestamp + 1;
     AMMLibEIP712.Order DEFAULT_ORDER;
 

--- a/contracts/test/forkMainnet/AMMWrapper/TradeCurveV1.t.sol
+++ b/contracts/test/forkMainnet/AMMWrapper/TradeCurveV1.t.sol
@@ -21,6 +21,7 @@ contract TestAMMWrapperTradeCurveV1 is TestAMMWrapper {
         userProxy.toAMM(payload);
 
         userTakerAsset.assertChange(-int256(order.takerAssetAmount));
+        // FIXME assert balance change precisely
         userMakerAsset.assertChangeGt(int256(order.makerAssetAmount));
     }
 }

--- a/contracts/test/forkMainnet/AMMWrapper/TradeSushiswap.t.sol
+++ b/contracts/test/forkMainnet/AMMWrapper/TradeSushiswap.t.sol
@@ -8,20 +8,26 @@ contract TestAMMWrapperTradeSushiswap is TestAMMWrapper {
     using BalanceSnapshot for BalanceSnapshot.Snapshot;
 
     function testTradeSushiswap() public {
-        uint256 feeFactor = 0;
         AMMLibEIP712.Order memory order = DEFAULT_ORDER;
         order.makerAddr = SUSHISWAP_ADDRESS;
         order.makerAssetAddr = ETH_ADDRESS;
         order.makerAssetAmount = 0.001 ether;
         bytes memory sig = _signTrade(userPrivateKey, order);
-        bytes memory payload = _genTradePayload(order, feeFactor, sig);
+        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig);
+
+        uint256 expectedOutAmount = ammQuoter.getMakerOutAmount(order.makerAddr, order.takerAssetAddr, order.makerAssetAddr, order.takerAssetAmount);
+        uint256 actualFee = (expectedOutAmount * DEFAULT_FEE_FACTOR) / LibConstant.BPS_MAX;
+        uint256 settleAmount = expectedOutAmount - actualFee;
 
         BalanceSnapshot.Snapshot memory userTakerAsset = BalanceSnapshot.take(user, order.takerAssetAddr);
         BalanceSnapshot.Snapshot memory userMakerAsset = BalanceSnapshot.take(user, order.makerAssetAddr);
+        // Collect fee in WETH directly
+        BalanceSnapshot.Snapshot memory feeCollectorMakerAsset = BalanceSnapshot.take(feeCollector, WETH_ADDRESS);
 
         userProxy.toAMM(payload);
 
         userTakerAsset.assertChange(-int256(order.takerAssetAmount));
-        userMakerAsset.assertChangeGt(int256(order.makerAssetAmount));
+        userMakerAsset.assertChange(int256(settleAmount));
+        feeCollectorMakerAsset.assertChange(int256(actualFee));
     }
 }

--- a/contracts/test/forkMainnet/AMMWrapperWithPath/TradeCurveV1.t.sol
+++ b/contracts/test/forkMainnet/AMMWrapperWithPath/TradeCurveV1.t.sol
@@ -10,13 +10,12 @@ contract TestAMMWrapperWithPathTradeCurveV1 is TestAMMWrapperWithPath {
     using BalanceSnapshot for BalanceSnapshot.Snapshot;
 
     function testTradeCurveV1() public {
-        uint256 feeFactor = 0;
         AMMLibEIP712.Order memory order = DEFAULT_ORDER;
         order.makerAddr = CURVE_USDT_POOL_ADDRESS;
         bytes memory sig = _signTrade(userPrivateKey, order);
         address[] memory path = new address[](0);
         bytes memory makerSpecificData = _encodeCurveData(1);
-        bytes memory payload = _genTradePayload(order, feeFactor, sig, makerSpecificData, path);
+        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, makerSpecificData, path);
 
         BalanceSnapshot.Snapshot memory userTakerAsset = BalanceSnapshot.take(user, order.takerAssetAddr);
         BalanceSnapshot.Snapshot memory userMakerAsset = BalanceSnapshot.take(user, order.makerAssetAddr);
@@ -25,6 +24,7 @@ contract TestAMMWrapperWithPathTradeCurveV1 is TestAMMWrapperWithPath {
         userProxy.toAMM(payload);
 
         userTakerAsset.assertChange(-int256(order.takerAssetAmount));
+        // FIXME assert balance change precisely
         userMakerAsset.assertChangeGt(int256(order.makerAssetAmount));
     }
 }

--- a/contracts/test/forkMainnet/AMMWrapperWithPath/TradeUniswapV3.t.sol
+++ b/contracts/test/forkMainnet/AMMWrapperWithPath/TradeUniswapV3.t.sol
@@ -14,30 +14,28 @@ contract TestAMMWrapperWithPathTradeUniswapV3 is TestAMMWrapperWithPath {
     uint24 constant INVALID_OVER_FEE = type(uint24).max;
 
     function testCannotTradeWithInvalidSignature() public {
-        uint256 feeFactor = 0;
         AMMLibEIP712.Order memory order = DEFAULT_ORDER;
         bytes memory sig = _signTrade(otherPrivateKey, order);
         address[] memory path = new address[](0);
         bytes memory makerSpecificData = bytes("");
-        bytes memory payload = _genTradePayload(order, feeFactor, sig, makerSpecificData, path);
+        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, makerSpecificData, path);
 
         vm.expectRevert("AMMWrapper: invalid user signature");
         userProxy.toAMM(payload);
     }
 
     function testCannotTradeSinglePoolWithInvalidSwapType() public {
-        uint256 feeFactor = 0;
         AMMLibEIP712.Order memory order = DEFAULT_ORDER;
         bytes memory sig = _signTrade(userPrivateKey, order);
         address[] memory path = new address[](0);
         bytes memory makerSpecificData = _encodeUniswapSinglePoolData(UNSUPPORTED_SWAP_TYPE, FEE_MEDIUM);
-        bytes memory payload = _genTradePayload(order, feeFactor, sig, makerSpecificData, path);
+        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, makerSpecificData, path);
 
         vm.expectRevert("AMMWrapper: unsupported UniswapV3 swap type");
         userProxy.toAMM(payload);
 
         makerSpecificData = _encodeUniswapSinglePoolData(INVALID_SWAP_TYPE, FEE_MEDIUM);
-        payload = _genTradePayload(order, feeFactor, sig, makerSpecificData, path);
+        payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, makerSpecificData, path);
 
         // No revert string as it violates SwapType enum's sanity check
         vm.expectRevert();
@@ -45,19 +43,18 @@ contract TestAMMWrapperWithPathTradeUniswapV3 is TestAMMWrapperWithPath {
     }
 
     function testCannotTradeSinglePoolWithInvalidPoolFee() public {
-        uint256 feeFactor = 0;
         AMMLibEIP712.Order memory order = DEFAULT_ORDER;
         bytes memory sig = _signTrade(userPrivateKey, order);
         address[] memory path = new address[](0);
         bytes memory makerSpecificData = _encodeUniswapSinglePoolData(SINGLE_POOL_SWAP_TYPE, INVALID_ZERO_FEE);
-        bytes memory payload = _genTradePayload(order, feeFactor, sig, makerSpecificData, path);
+        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, makerSpecificData, path);
 
         // No revert string for invalid pool fee
         vm.expectRevert();
         userProxy.toAMM(payload);
 
         makerSpecificData = _encodeUniswapSinglePoolData(SINGLE_POOL_SWAP_TYPE, INVALID_OVER_FEE);
-        payload = _genTradePayload(order, feeFactor, sig, makerSpecificData, path);
+        payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, makerSpecificData, path);
 
         // No revert string for invalid pool fee
         vm.expectRevert();
@@ -65,13 +62,12 @@ contract TestAMMWrapperWithPathTradeUniswapV3 is TestAMMWrapperWithPath {
     }
 
     function testCannotTradeMultiPoolWithInvalidPathFormat() public {
-        uint256 feeFactor = 0;
         AMMLibEIP712.Order memory order = DEFAULT_ORDER;
         bytes memory sig = _signTrade(userPrivateKey, order);
         address[] memory path = DEFAULT_MULTI_HOP_PATH;
         bytes memory garbageData = new bytes(0);
         bytes memory makerSpecificData = abi.encode(MULTI_POOL_SWAP_TYPE, garbageData);
-        bytes memory payload = _genTradePayload(order, feeFactor, sig, makerSpecificData, path);
+        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, makerSpecificData, path);
 
         vm.expectRevert("toAddress_outOfBounds");
         userProxy.toAMM(payload);
@@ -80,35 +76,33 @@ contract TestAMMWrapperWithPathTradeUniswapV3 is TestAMMWrapperWithPath {
         garbageData[0] = "5";
         garbageData[1] = "5";
         makerSpecificData = abi.encode(MULTI_POOL_SWAP_TYPE, garbageData); // Update the path variable
-        payload = _genTradePayload(order, feeFactor, sig, makerSpecificData, path);
+        payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, makerSpecificData, path);
 
         vm.expectRevert("toAddress_outOfBounds");
         userProxy.toAMM(payload);
     }
 
     function testCannotTradeMultiPoolWithInvalidFeeFormat() public {
-        uint256 feeFactor = 0;
         AMMLibEIP712.Order memory order = DEFAULT_ORDER;
         bytes memory sig = _signTrade(userPrivateKey, order);
         address[] memory path = new address[](1);
         path[0] = order.takerAssetAddr;
         uint24[] memory fees = new uint24[](0); // No fees specified
         bytes memory makerSpecificData = _encodeUniswapMultiPoolData(MULTI_POOL_SWAP_TYPE, path, fees);
-        bytes memory payload = _genTradePayload(order, feeFactor, sig, makerSpecificData, path);
+        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, makerSpecificData, path);
 
         vm.expectRevert("toUint24_outOfBounds");
         userProxy.toAMM(payload);
     }
 
     function testCannotTradeMultiPoolWithMismatchAsset() public {
-        uint256 feeFactor = 0;
         AMMLibEIP712.Order memory order = DEFAULT_ORDER;
         bytes memory sig = _signTrade(userPrivateKey, order);
         address[] memory path = DEFAULT_MULTI_HOP_PATH;
         path[0] = user;
         uint24[] memory fees = DEFAULT_MULTI_HOP_POOL_FEES;
         bytes memory makerSpecificData = _encodeUniswapMultiPoolData(MULTI_POOL_SWAP_TYPE, path, fees);
-        bytes memory payload = _genTradePayload(order, feeFactor, sig, makerSpecificData, path);
+        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, makerSpecificData, path);
 
         vm.expectRevert("UniswapV3: first element of path must match token in");
         userProxy.toAMM(payload);
@@ -116,18 +110,17 @@ contract TestAMMWrapperWithPathTradeUniswapV3 is TestAMMWrapperWithPath {
         path = DEFAULT_MULTI_HOP_PATH;
         path[2] = user;
         makerSpecificData = _encodeUniswapMultiPoolData(MULTI_POOL_SWAP_TYPE, path, fees); // Update the path variable
-        payload = _genTradePayload(order, feeFactor, sig, makerSpecificData, path);
+        payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, makerSpecificData, path);
         vm.expectRevert("UniswapV3: last element of path must match token out");
         userProxy.toAMM(payload);
     }
 
     function testCannotTradeWhenPayloadSeenBefore() public {
-        uint256 feeFactor = 0;
         AMMLibEIP712.Order memory order = DEFAULT_ORDER;
         bytes memory sig = _signTrade(userPrivateKey, order);
         address[] memory path = new address[](0);
         bytes memory makerSpecificData = _encodeUniswapSinglePoolData(SINGLE_POOL_SWAP_TYPE, FEE_MEDIUM);
-        bytes memory payload = _genTradePayload(order, feeFactor, sig, makerSpecificData, path);
+        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, makerSpecificData, path);
 
         userProxy.toAMM(payload);
 
@@ -136,59 +129,96 @@ contract TestAMMWrapperWithPathTradeUniswapV3 is TestAMMWrapperWithPath {
     }
 
     function testTradeWithSingleExactInput() public {
-        uint256 feeFactor = 0;
         AMMLibEIP712.Order memory order = DEFAULT_ORDER;
         order.makerAssetAddr = ETH_ADDRESS;
         order.makerAssetAmount = 0.001 ether;
         bytes memory sig = _signTrade(userPrivateKey, order);
         address[] memory path = new address[](0);
         bytes memory makerSpecificData = _encodeUniswapSinglePoolData(SINGLE_POOL_SWAP_TYPE, FEE_MEDIUM);
-        bytes memory payload = _genTradePayload(order, feeFactor, sig, makerSpecificData, path);
+        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, makerSpecificData, path);
+
+        uint256 expectedOutAmount = ammQuoter.getMakerOutAmountWithPath(
+            order.makerAddr,
+            order.takerAssetAddr,
+            order.makerAssetAddr,
+            order.takerAssetAmount,
+            path,
+            makerSpecificData
+        );
+        uint256 actualFee = (expectedOutAmount * DEFAULT_FEE_FACTOR) / LibConstant.BPS_MAX;
+        uint256 settleAmount = expectedOutAmount - actualFee;
 
         BalanceSnapshot.Snapshot memory userTakerAsset = BalanceSnapshot.take(user, order.takerAssetAddr);
         BalanceSnapshot.Snapshot memory userMakerAsset = BalanceSnapshot.take(user, order.makerAssetAddr);
+        // Collect fee in WETH directly
+        BalanceSnapshot.Snapshot memory feeCollectorMakerAsset = BalanceSnapshot.take(feeCollector, WETH_ADDRESS);
 
         userProxy.toAMM(payload);
 
         userTakerAsset.assertChange(-int256(order.takerAssetAmount));
-        userMakerAsset.assertChangeGt(int256(order.makerAssetAmount));
+        userMakerAsset.assertChange(int256(settleAmount));
+        feeCollectorMakerAsset.assertChange(int256(actualFee));
     }
 
     function testTradeWithSingleHop() public {
-        uint256 feeFactor = 0;
         AMMLibEIP712.Order memory order = DEFAULT_ORDER;
         bytes memory sig = _signTrade(userPrivateKey, order);
         address[] memory path = new address[](0);
         bytes memory makerSpecificData = _encodeUniswapSinglePoolData(SINGLE_POOL_SWAP_TYPE, FEE_MEDIUM);
-        bytes memory payload = _genTradePayload(order, feeFactor, sig, makerSpecificData, path);
+        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, makerSpecificData, path);
+
+        uint256 expectedOutAmount = ammQuoter.getMakerOutAmountWithPath(
+            order.makerAddr,
+            order.takerAssetAddr,
+            order.makerAssetAddr,
+            order.takerAssetAmount,
+            path,
+            makerSpecificData
+        );
+        uint256 actualFee = (expectedOutAmount * DEFAULT_FEE_FACTOR) / LibConstant.BPS_MAX;
+        uint256 settleAmount = expectedOutAmount - actualFee;
 
         BalanceSnapshot.Snapshot memory userTakerAsset = BalanceSnapshot.take(user, order.takerAssetAddr);
         BalanceSnapshot.Snapshot memory userMakerAsset = BalanceSnapshot.take(user, order.makerAssetAddr);
+        BalanceSnapshot.Snapshot memory feeCollectorMakerAsset = BalanceSnapshot.take(feeCollector, order.makerAssetAddr);
 
         vm.prank(relayer, relayer);
         userProxy.toAMM(payload);
 
         userTakerAsset.assertChange(-int256(order.takerAssetAmount));
-        userMakerAsset.assertChangeGt(int256(order.makerAssetAmount));
+        userMakerAsset.assertChange(int256(settleAmount));
+        feeCollectorMakerAsset.assertChange(int256(actualFee));
     }
 
     function testTradeWithMultiHop() public {
-        uint256 feeFactor = 0;
         AMMLibEIP712.Order memory order = DEFAULT_ORDER;
         bytes memory sig = _signTrade(userPrivateKey, order);
         address[] memory path = DEFAULT_MULTI_HOP_PATH;
         uint24[] memory fees = DEFAULT_MULTI_HOP_POOL_FEES;
         bytes memory makerSpecificData = _encodeUniswapMultiPoolData(MULTI_POOL_SWAP_TYPE, path, fees);
-        bytes memory payload = _genTradePayload(order, feeFactor, sig, makerSpecificData, path);
+        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, makerSpecificData, path);
+
+        uint256 expectedOutAmount = ammQuoter.getMakerOutAmountWithPath(
+            order.makerAddr,
+            order.takerAssetAddr,
+            order.makerAssetAddr,
+            order.takerAssetAmount,
+            path,
+            makerSpecificData
+        );
+        uint256 actualFee = (expectedOutAmount * DEFAULT_FEE_FACTOR) / LibConstant.BPS_MAX;
+        uint256 settleAmount = expectedOutAmount - actualFee;
 
         BalanceSnapshot.Snapshot memory userTakerAsset = BalanceSnapshot.take(user, order.takerAssetAddr);
         BalanceSnapshot.Snapshot memory userMakerAsset = BalanceSnapshot.take(user, order.makerAssetAddr);
+        BalanceSnapshot.Snapshot memory feeCollectorMakerAsset = BalanceSnapshot.take(feeCollector, order.makerAssetAddr);
 
         vm.prank(relayer, relayer);
         userProxy.toAMM(payload);
 
         userTakerAsset.assertChange(-int256(order.takerAssetAmount));
-        userMakerAsset.assertChangeGt(int256(order.makerAssetAmount));
+        userMakerAsset.assertChange(int256(settleAmount));
+        feeCollectorMakerAsset.assertChange(int256(actualFee));
     }
 
     function testEmitSwappedEvent() public {


### PR DESCRIPTION
Since the actual amount that user will receive is `outupt * (1 - feeRate)`, so the `minAmountOut` should be calculated as `order.makerAssetAmount * (1 / 1 - feeRate)`.

- Keep default fee factor in most cases instead of 0
- Assert balance change precisely (replace `assertChangeGt` with `assertChange`)
- Lower default fee factor in `AMMWrapper` tests so the order rate is much more straightforward

WIP
- The Curve v1 quote returned by AMMQuoter is different from the result of swapping, still debugging.