### PR TITLE
strictly event emitted

### DIFF
--- a/contracts/test/PermanentStorage.t.sol
+++ b/contracts/test/PermanentStorage.t.sol
@@ -93,7 +93,7 @@ contract PermanentStorageTest is Test {
 
     function testUpgradeAMMWrapper() public {
         assertEq(permanentStorage.ammWrapperAddr(), address(0));
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit UpgradeAMMWrapper(strategy);
         permanentStorage.upgradeAMMWrapper(strategy);
         assertEq(permanentStorage.ammWrapperAddr(), strategy);
@@ -107,7 +107,7 @@ contract PermanentStorageTest is Test {
 
     function testUpgradeRFQ() public {
         assertEq(permanentStorage.rfqAddr(), address(0));
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit UpgradeRFQ(strategy);
         permanentStorage.upgradeRFQ(strategy);
         assertEq(permanentStorage.rfqAddr(), strategy);
@@ -121,7 +121,7 @@ contract PermanentStorageTest is Test {
 
     function testUpgradeLimitOrder() public {
         assertEq(permanentStorage.limitOrderAddr(), address(0));
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit UpgradeLimitOrder(strategy);
         permanentStorage.upgradeLimitOrder(strategy);
         assertEq(permanentStorage.limitOrderAddr(), strategy);
@@ -135,7 +135,7 @@ contract PermanentStorageTest is Test {
 
     function testUpgradeWETH() public {
         assertEq(permanentStorage.wethAddr(), address(0));
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit UpgradeWETH(strategy);
         permanentStorage.upgradeWETH(strategy);
         assertEq(permanentStorage.wethAddr(), strategy);
@@ -164,13 +164,13 @@ contract PermanentStorageTest is Test {
 
         assertFalse(permanentStorage.hasPermission(storageId, strategy));
 
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit SetPermission(storageId, strategy, true);
 
         permanentStorage.setPermission(storageId, strategy, true);
         assertTrue(permanentStorage.hasPermission(storageId, strategy));
 
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit SetPermission(storageId, strategy, false);
 
         permanentStorage.setPermission(storageId, strategy, false);
@@ -298,7 +298,7 @@ contract PermanentStorageTest is Test {
             address _relayer = DEFAULT_RELAYERS[i];
             bool valid = DEFAULT_RELAYER_VALIDS[i];
             assertFalse(permanentStorage.isRelayerValid(_relayer));
-            vm.expectEmit(false, false, false, true);
+            vm.expectEmit(true, true, true, true);
             emit SetRelayerValid(_relayer, valid);
         }
         permanentStorage.setRelayersValid(DEFAULT_RELAYERS, DEFAULT_RELAYER_VALIDS);
@@ -340,7 +340,7 @@ contract PermanentStorageTest is Test {
         bytes32 storageId = permanentStorage.curveTokenIndexStorageId();
         permanentStorage.setPermission(storageId, address(this), true);
 
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit SetCurvePoolInfo(DEFAULT_CURVE_POOL_ADDRESS, DEFAULT_CURVE_POOL_UNDERLYING_COINS, DEFAULT_CURVE_POOL_COINS, DEFAULT_CURVE_SUPPORT_GET_DX);
         permanentStorage.setCurvePoolInfo(
             DEFAULT_CURVE_POOL_ADDRESS,

--- a/contracts/test/RFQ.t.sol
+++ b/contracts/test/RFQ.t.sol
@@ -409,7 +409,7 @@ contract RFQTest is StrategySharedSetup {
      *********************************/
 
     function _expectEvent(RFQLibEIP712.Order memory order) internal {
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, true, true, true);
         emit FillOrder(
             "RFQ v1",
             RFQLibEIP712._getTransactionHash(order),

--- a/contracts/test/Spender.t.sol
+++ b/contracts/test/Spender.t.sol
@@ -137,7 +137,7 @@ contract SpenderTest is BalanceUtil {
     }
 
     function testTeardownAllowanceTarget() public {
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit TearDownAllowanceTarget(block.timestamp);
 
         spender.teardownAllowanceTarget();

--- a/contracts/test/TreasuryVester.t.sol
+++ b/contracts/test/TreasuryVester.t.sol
@@ -111,7 +111,7 @@ contract TreasuryVesterTest is Test {
         vm.expectEmit(
             false, // We do not check the deployed Vester address as it's deterministic generated and irrelevant to correctness
             true,
-            false,
+            true,
             true
         );
         emit VesterCreated(

--- a/contracts/test/forkMainnet/AMMWrapperWithPath/TradeUniswapV3.t.sol
+++ b/contracts/test/forkMainnet/AMMWrapperWithPath/TradeUniswapV3.t.sol
@@ -225,7 +225,7 @@ contract TestAMMWrapperWithPathTradeUniswapV3 is TestAMMWrapperWithPath {
                 DEFAULT_MULTI_HOP_PATH,
                 makerSpecificData
             );
-            vm.expectEmit(false, false, false, true);
+            vm.expectEmit(true, true, true, true);
             emit Swapped(
                 "Uniswap V3",
                 AMMLibEIP712._getOrderHash(order),

--- a/contracts/test/forkMainnet/RewardDistributor.t.sol
+++ b/contracts/test/forkMainnet/RewardDistributor.t.sol
@@ -168,7 +168,7 @@ contract RewardDistributorTest is Test {
     event SetOperator(address operator, bool enable);
 
     function testSetOperator() public {
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit SetOperator(user, true);
         rewardDistributor.setOperator(user, true);
         assertTrue(rewardDistributor.isOperator(user));
@@ -194,7 +194,7 @@ contract RewardDistributorTest is Test {
     function testSetMiningFactor() public {
         uint8 newMiningFactor = 10;
 
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit SetMiningFactor(newMiningFactor);
         rewardDistributor.setMiningFactor(newMiningFactor);
 
@@ -214,7 +214,7 @@ contract RewardDistributorTest is Test {
     event SetTreasury(address treasury);
 
     function testSetTreasury() public {
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit SetTreasury(user);
         rewardDistributor.setTreasury(user);
         assertEq(rewardDistributor.treasury(), user);
@@ -240,7 +240,7 @@ contract RewardDistributorTest is Test {
     function testSetLonStaking() public {
         address newLonStaking = address(lon);
 
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit SetLonStaking(newLonStaking);
         rewardDistributor.setLonStaking(newLonStaking);
 
@@ -260,7 +260,7 @@ contract RewardDistributorTest is Test {
     event SetMiningTreasury(address miningTreasury);
 
     function testSetMiningTreasury() public {
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit SetMiningTreasury(user);
         rewardDistributor.setMiningTreasury(user);
         assertEq(rewardDistributor.miningTreasury(), user);
@@ -279,7 +279,7 @@ contract RewardDistributorTest is Test {
     event SetFeeTokenRecipient(address feeTokenRecipient);
 
     function testSetFeeTokenRecipient() public {
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit SetFeeTokenRecipient(user);
         rewardDistributor.setFeeTokenRecipient(user);
         assertEq(rewardDistributor.feeTokenRecipient(), user);
@@ -304,7 +304,7 @@ contract RewardDistributorTest is Test {
 
         BalanceSnapshot.Snapshot memory ownerLon = BalanceSnapshot.take(address(this), address(lon));
 
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit Recovered(address(lon), recoverAmount);
         rewardDistributor.recoverERC20(address(lon), recoverAmount);
 
@@ -325,7 +325,7 @@ contract RewardDistributorTest is Test {
 
     function testSetBuybackInterval() public {
         uint32 newBuybackInterval = 86400;
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit SetBuybackInterval(newBuybackInterval);
         rewardDistributor.setBuybackInterval(newBuybackInterval);
     }
@@ -367,10 +367,10 @@ contract RewardDistributorTest is Test {
         strategyAddrs[0] = address(new MockStrategy());
         strategyAddrs[1] = address(new MockStrategy());
 
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit SetStrategy(0, strategyAddrs[0]);
 
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit SetStrategy(1, strategyAddrs[1]);
 
         _setStrategyAddrs(strategyAddrs);
@@ -488,9 +488,9 @@ contract RewardDistributorTest is Test {
     event SetFeeToken(address feeToken, uint256 exchangeIndex, address[] path, uint256 LFactor, uint256 RFactor, uint256 minBuy, uint256 maxBuy);
 
     function _expectFeeTokenSetEvents(SetFeeTokenParams memory params) internal {
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit EnableFeeToken(params.feeTokenAddr, params.enable);
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit SetFeeToken(params.feeTokenAddr, params.exchangeIndex, params.path, params.LFactor, params.RFactor, params.minBuy, params.maxBuy);
     }
 
@@ -534,7 +534,7 @@ contract RewardDistributorTest is Test {
         feeTokens[1] = validFeeToken;
 
         // First fee token will fail to be set
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit SetFeeTokenFailure(invalidFeeToken.feeTokenAddr, "invalid swap path", bytes(""));
 
         // Second fee token will be set
@@ -586,7 +586,7 @@ contract RewardDistributorTest is Test {
     }
 
     function testEnableFeeToken() public {
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit EnableFeeToken(address(usdt), true);
         rewardDistributor.enableFeeToken(address(usdt), true);
 
@@ -748,10 +748,10 @@ contract RewardDistributorTest is Test {
 
         _expectBuybackEvent(feeToken, buybackToSwap, lonOut);
 
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit DistributeLon(lonToTreasury, lonToStaking);
 
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit MintLon(lonToMiningTreasury);
 
         vm.prank(user, user);
@@ -801,10 +801,10 @@ contract RewardDistributorTest is Test {
 
         _expectBuybackEvent(feeToken, buybackToSwap, lonOut);
 
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit DistributeLon(lonToTreasury, lonToStaking);
 
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit MintLon(lonToMiningTreasury);
 
         vm.prank(user, user);
@@ -831,10 +831,10 @@ contract RewardDistributorTest is Test {
         BalanceSnapshot.Snapshot memory treasuryLON = BalanceSnapshot.take(treasury, address(lon));
         BalanceSnapshot.Snapshot memory miningTreasuryLON = BalanceSnapshot.take(miningTreasury, address(lon));
 
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit DistributeLon(lonToTreasury, lonToStaking);
 
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit MintLon(lonToMiningTreasury);
 
         vm.prank(user, user);
@@ -875,7 +875,7 @@ contract RewardDistributorTest is Test {
         uint256 swapAmount,
         uint256 lonAmount
     ) internal {
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit BuyBack(feeToken.feeTokenAddr, swapAmount, lonAmount, feeToken.LFactor, feeToken.RFactor, feeToken.minBuy, feeToken.maxBuy);
     }
 
@@ -930,16 +930,16 @@ contract RewardDistributorTest is Test {
         (uint256 lonToTreasury, uint256 lonToStaking, uint256 lonToMiningTreasury) = _splitBuybackLON(feeToken, lonOut);
 
         // First buyback will fail
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit BuyBackFailure(address(lon), LON_FEE_TOKEN.maxBuy, "fee token is not enabled", bytes(""));
 
         // Second buyback will succeed
         _expectBuybackEvent(feeToken, buybackToSwap, lonOut);
 
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit DistributeLon(lonToTreasury, lonToStaking);
 
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit MintLon(lonToMiningTreasury);
 
         vm.prank(user, user);

--- a/foundry.toml
+++ b/foundry.toml
@@ -22,4 +22,5 @@ fuzz_max_global_rejects = 10000000
 auto_detect_solc = true                                       # enable auto-detection of the appropriate solc version to use
 ignored_error_codes = []                                      # a list of ignored solc error codes
 
+
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config


### PR DESCRIPTION
- After overviewing the whole tokenlon contracts testing, I turn the all event unit testing to emitting strictly. Namely, the event testing must be `expectEmit(true,  true, true, true)`.
- Related Internal documentation: **Strictly Event Emitting Unit Testing in Tokenlon**