### PR TITLE
spec: update fork_block_number of readme.md

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -41,7 +41,6 @@ jobs:
       - name: Test
         env:
           MAINNET_NODE_RPC_URL: ${{ secrets.MAINNET_NODE_RPC_URL }}
-          FORK_BLOCK_NUMBER: 15451000
         run: |
           yarn run test-foundry-local
           yarn run test-foundry-fork

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Tokenlon is a decentralized exchange and payment settlement protocol based on bl
 
 ```
 MAINNET_NODE_RPC_URL=https://eth-mainnet.alchemyapi.io/v2/#####__YOUR_SECRET__#####
-FORK_BLOCK_NUMBER=14340000
+FORK_BLOCK_NUMBER=15451000
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -42,13 +42,11 @@ Tokenlon is a decentralized exchange and payment settlement protocol based on bl
 -   [foundry](https://github.com/foundry-rs/foundry)
 -   Environment Variables (Used for foundry fork tests)
     -   `MAINNET_NODE_RPC_URL`: The RPC URL for accessing forked states.
-    -   `FORK_BLOCK_NUMBER`: Specfic block number of forked states.
 
 ### Example
 
 ```
 MAINNET_NODE_RPC_URL=https://eth-mainnet.alchemyapi.io/v2/#####__YOUR_SECRET__#####
-FORK_BLOCK_NUMBER=15451000
 ```
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "solhint \"contracts/**/*.sol\"",
     "compile": "hardhat compile --show-stack-traces --force && forge build --force",
     "test-foundry-local": "forge test -vvv --force --no-match-path 'contracts/test/forkMainnet/*.t.sol'",
-    "test-foundry-fork": "forge test -vvv --force --fork-url $MAINNET_NODE_RPC_URL --fork-block-number $FORK_BLOCK_NUMBER --match-path 'contracts/test/forkMainnet/*.t.sol'"
+    "test-foundry-fork": "forge test -vvv --force --fork-url $MAINNET_NODE_RPC_URL --fork-block-number 15451000 --match-path 'contracts/test/forkMainnet/*.t.sol'"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-etherscan": "^3.1.0",


### PR DESCRIPTION
## Modify the FORK_BLOCK_NUMBER parameter of README.md to be consistent with .github/workflows/node.js.yml.

## How to verify
```shell
~ % git clone git@github.com:consenlabs/tokenlon-contracts.git
~ % cd tokenlon-contracts && yarn run setup && yarn run compile
tokenlon-contracts % MAINNET_NODE_RPC_URL="https://eth-mainnet.g.alchemy.com/v2/<Your API Key from https://dashboard.alchemy.com/ website>"
tokenlon-contracts % yarn run test-foundry-fork
```