### PR TITLE
add default env value for tests

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -40,7 +40,6 @@ jobs:
           yarn run compile
       - name: Test
         env:
-          DEPLOYED: false
           MAINNET_NODE_RPC_URL: ${{ secrets.MAINNET_NODE_RPC_URL }}
         run: |
           yarn run test-foundry-local

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "check-pretty": "prettier --check .",
     "lint": "solhint \"contracts/**/*.sol\"",
     "compile": "hardhat compile --show-stack-traces --force && forge build --force",
-    "test-foundry-local": "forge test -vvv --force --no-match-path 'contracts/test/forkMainnet/*.t.sol'",
-    "test-foundry-fork": "forge test -vvv --force --fork-url $MAINNET_NODE_RPC_URL --fork-block-number 15451000 --match-path 'contracts/test/forkMainnet/*.t.sol'"
+    "test-foundry-local": "DEPLOYED=false forge test -vvv --force --no-match-path 'contracts/test/forkMainnet/*.t.sol'",
+    "test-foundry-fork": "DEPLOYED=false forge test -vvv --force --fork-url $MAINNET_NODE_RPC_URL --fork-block-number 15451000 --match-path 'contracts/test/forkMainnet/*.t.sol'"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-etherscan": "^3.1.0",


### PR DESCRIPTION
Add default env value in `package.json` so no need to set env variable before running normal tests.