### PR TITLE
feat: spendWithPermit should contain transaction or order hash

### DIFF
--- a/contracts/RFQ.sol
+++ b/contracts/RFQ.sol
@@ -142,7 +142,7 @@ contract RFQ is IRFQ, StrategyBase, ReentrancyGuard, SignatureValidator, BaseLib
             user: _order.makerAddr,
             recipient: address(this),
             amount: _order.makerAssetAmount,
-            txHash: _vars.orderHash,
+            actionHash: _vars.orderHash,
             expiry: uint64(_order.deadline)
         });
 
@@ -153,7 +153,7 @@ contract RFQ is IRFQ, StrategyBase, ReentrancyGuard, SignatureValidator, BaseLib
             user: _order.takerAddr,
             recipient: address(this),
             amount: _order.takerAssetAmount,
-            txHash: _vars.transactionHash,
+            actionHash: _vars.transactionHash,
             expiry: uint64(_order.deadline)
         });
 

--- a/contracts/test/RFQ.t.sol
+++ b/contracts/test/RFQ.t.sol
@@ -615,7 +615,7 @@ contract RFQTest is StrategySharedSetup {
             user: defaultOrder.makerAddr,
             recipient: address(rfq),
             amount: defaultOrder.makerAssetAmount,
-            txHash: RFQLibEIP712._getOrderHash(defaultOrder),
+            actionHash: RFQLibEIP712._getOrderHash(defaultOrder),
             expiry: uint64(defaultOrder.deadline)
         });
 
@@ -626,7 +626,7 @@ contract RFQTest is StrategySharedSetup {
             user: defaultOrder.takerAddr,
             recipient: address(rfq),
             amount: defaultOrder.takerAssetAmount,
-            txHash: RFQLibEIP712._getTransactionHash(defaultOrder),
+            actionHash: RFQLibEIP712._getTransactionHash(defaultOrder),
             expiry: uint64(defaultOrder.deadline)
         });
         return (makerAssetPermit, takerAssetPermit);
@@ -643,7 +643,7 @@ contract RFQTest is StrategySharedSetup {
         SpenderLibEIP712.SpendWithPermit memory spendWithPermit,
         SignatureValidator.SignatureType sigType
     ) internal returns (bytes memory sig) {
-        uint256 SPEND_WITH_PERMIT_TYPEHASH = 0x356b0c4ef9d6005a11dc7bead0f1cea62bd30d1e5d59c407e9a7c13f54b24970;
+        uint256 SPEND_WITH_PERMIT_TYPEHASH = 0x52718c957261b99fd72e63478d85d1267cdc812e8249f5a2623566c1818e1ed0;
         bytes32 structHash = keccak256(
             abi.encode(
                 SPEND_WITH_PERMIT_TYPEHASH,
@@ -652,7 +652,7 @@ contract RFQTest is StrategySharedSetup {
                 spendWithPermit.user,
                 spendWithPermit.recipient,
                 spendWithPermit.amount,
-                spendWithPermit.txHash,
+                spendWithPermit.actionHash,
                 spendWithPermit.expiry
             )
         );

--- a/contracts/test/Spender.t.sol
+++ b/contracts/test/Spender.t.sol
@@ -86,7 +86,7 @@ contract SpenderTest is BalanceUtil {
             user, // user
             recipient, // receipient
             100 * 1e18, // amount
-            bytes32(0x0), // txHash
+            bytes32(0x0), // actionHash
             EXPIRY // expiry
         );
 
@@ -453,7 +453,7 @@ contract SpenderTest is BalanceUtil {
     }
 
     function _signSpendWithPermit(uint256 privateKey, SpenderLibEIP712.SpendWithPermit memory spendWithPermit) internal returns (bytes memory sig) {
-        uint256 SPEND_WITH_PERMIT_TYPEHASH = 0x356b0c4ef9d6005a11dc7bead0f1cea62bd30d1e5d59c407e9a7c13f54b24970;
+        uint256 SPEND_WITH_PERMIT_TYPEHASH = 0x52718c957261b99fd72e63478d85d1267cdc812e8249f5a2623566c1818e1ed0;
         bytes32 structHash = keccak256(
             abi.encode(
                 SPEND_WITH_PERMIT_TYPEHASH,
@@ -462,7 +462,7 @@ contract SpenderTest is BalanceUtil {
                 spendWithPermit.user,
                 spendWithPermit.recipient,
                 spendWithPermit.amount,
-                spendWithPermit.txHash,
+                spendWithPermit.actionHash,
                 spendWithPermit.expiry
             )
         );

--- a/contracts/utils/SpenderLibEIP712.sol
+++ b/contracts/utils/SpenderLibEIP712.sol
@@ -8,7 +8,7 @@ library SpenderLibEIP712 {
         address user;
         address recipient;
         uint256 amount;
-        bytes32 txHash;
+        bytes32 actionHash;
         uint64 expiry;
     }
     /*
@@ -20,13 +20,13 @@ library SpenderLibEIP712 {
                 "address user,",
                 "address recipient,",
                 "uint256 amount,",
-                "bytes32 txHash,",
+                "bytes32 actionHash,",
                 "uint64 expiry",
                 ")"
             )
         );
     */
-    uint256 public constant SPEND_WITH_PERMIT_TYPEHASH = 0x356b0c4ef9d6005a11dc7bead0f1cea62bd30d1e5d59c407e9a7c13f54b24970;
+    uint256 public constant SPEND_WITH_PERMIT_TYPEHASH = 0x52718c957261b99fd72e63478d85d1267cdc812e8249f5a2623566c1818e1ed0;
 
     function _getSpendWithPermitHash(SpendWithPermit memory _spendWithPermit) internal pure returns (bytes32) {
         return
@@ -38,7 +38,7 @@ library SpenderLibEIP712 {
                     _spendWithPermit.user,
                     _spendWithPermit.recipient,
                     _spendWithPermit.amount,
-                    _spendWithPermit.txHash,
+                    _spendWithPermit.actionHash,
                     _spendWithPermit.expiry
                 )
             );


### PR DESCRIPTION
## feat: spendWithPermit should contain transaction or order hash
    
1. To prevent the signature from being used by another transaction in the same strategy contract, the spendWithPermit must contain the hash of the transaction or order the user wants to execute.
2. Replace txHash in spendWithPermit with actionHash since actionHash will not be confused with blockchain's txHash.
3. The value of actionHash is the hash of the transaction, order or deposit hash calculated in each (AMM, RFQ, L2Deposit, LimitOrder, etc.) strategy contract.
4. Verify command:
```shell
tokenlon-contracts % DEPLOYED=false forge test -vvv --match-path 'contracts/test/Spender.t.sol'
tokenlon-contracts % DEPLOYED=false forge test -vvv --match-path 'contracts/test/RFQ.t.sol'
```


<details>
  <summary>Output: (Please click here to expand)</summary>
    <pre><code>

tokenlon-contracts % DEPLOYED=false forge test -vvv --match-path 'contracts/test/Spender.t.sol'

warning: Unknown section [default] found in foundry.toml. This notation for profiles has been deprecated and may result in the profile not being registered in future versions. Please use [profile.default] instead or run `forge config --fix`.
[⠒] Compiling...
No files changed, compilation skipped

Running 36 tests for contracts/test/Spender.t.sol:SpenderTest
[PASS] testAcceptAsOwner() (gas: 30485)
[PASS] testAuthorizeWithTimelock() (gas: 90519)
[PASS] testAuthorizeWithoutTimelock() (gas: 43606)
[PASS] testCannotAcceptAsOwnerByNonPendingOwner() (gas: 39626)
[PASS] testCannotAuthorizeByUser() (gas: 22341)
[PASS] testCannotNominateNewOwnerByUser() (gas: 13476)
[PASS] testCannotSimulateByNotAuthorized() (gas: 42278)
[PASS] testCannotSpendFromUserByNotAuthorized() (gas: 17870)
[PASS] testCannotSpendFromUserInsufficientBalance_NoReturnValueToken() (gas: 39636)
[PASS] testCannotSpendFromUserInsufficientBalance_ReturnFalseToken() (gas: 42065)
[PASS] testCannotSpendFromUserToByNotAuthorized() (gas: 18125)
[PASS] testCannotSpendFromUserToInsufficientBalance_NoReturnValueToken() (gas: 41863)
[PASS] testCannotSpendFromUserToInsufficientBalance_ReturnFalseToken() (gas: 44317)
[PASS] testCannotSpendFromUserToWithBlakclistedToken() (gas: 46744)
[PASS] testCannotSpendFromUserToWithDeflationaryToken() (gas: 97466)
[PASS] testCannotSpendFromUserToWithPermitByNotAuthorized() (gas: 34112)
[PASS] testCannotSpendFromUserToWithPermitByWrongSigner() (gas: 60650)
[PASS] testCannotSpendFromUserToWithPermitWithBlacklistedToken() (gas: 92421)
[PASS] testCannotSpendFromUserToWithPermitWithExpiredPermit() (gas: 29698)
[PASS] testCannotSpendFromUserToWithPermitWithSamePermit() (gas: 122919)
[PASS] testCannotSpendFromUserToWithPermitWithWrongAmount() (gas: 60721)
[PASS] testCannotSpendFromUserToWithPermitWithWrongRecipient() (gas: 62858)
[PASS] testCannotSpendFromUserToWithPermitWithWrongRequester() (gas: 32088)
[PASS] testCannotSpendFromUserToWithPermitWithWrongToken() (gas: 62829)
[PASS] testCannotSpendFromUserWithBlakclistedToken() (gas: 44602)
[PASS] testCannotSpendFromUserWithDeflationaryToken() (gas: 95281)
[PASS] testDeauthorize() (gas: 35509)
[PASS] testNominateNewOwner() (gas: 34527)
[PASS] testSetNewSpender() (gas: 2496638)
[PASS] testSimulate() (gas: 125382)
[PASS] testSpendFromUser() (gas: 72176)
[PASS] testSpendFromUserTo() (gas: 74608)
[PASS] testSpendFromUserToWithNoReturnValueToken() (gas: 74006)
[PASS] testSpendFromUserToWithPermit() (gas: 124722)
[PASS] testSpendFromUserWithNoReturnValueToken() (gas: 71484)
[PASS] testTeardownAllowanceTarget() (gas: 27902)
Test result: ok. 36 passed; 0 failed; finished in 19.35ms

tokenlon-contracts % DEPLOYED=false forge test -vvv --match-path 'contracts/test/RFQ.t.sol'

warning: Unknown section [default] found in foundry.toml. This notation for profiles has been deprecated and may result in the profile not being registered in future versions. Please use [profile.default] instead or run `forge config --fix`.
[⠃] Compiling...
No files changed, compilation skipped

Running 22 tests for contracts/test/RFQ.t.sol:RFQTest
[PASS] testCannotDepositETHByNotOwner() (gas: 13174)
[PASS] testCannotFillWithExpiredOrder() (gas: 82349)
[PASS] testCannotFillWithInvalidMakerSig() (gas: 91003)
[PASS] testCannotFillWithInvalidUserSig() (gas: 97590)
[PASS] testCannotFillWithInvalidUserWallet() (gas: 92504)
[PASS] testCannotFillWithSamePayloadAgain() (gas: 328392)
[PASS] testCannotSetAllowanceCloseAllowanceByNotOwner() (gas: 20502)
[PASS] testCannotSetFeeCollectorByNotOwner() (gas: 13498)
[PASS] testCannotUpgradeSpenderByNotOwner() (gas: 13584)
[PASS] testCannotUpgradeSpenderToZeroAddress() (gas: 13551)
[PASS] testDepositETH() (gas: 56340)
[PASS] testEmitSwappedEvent() (gas: 309802)
[PASS] testFillAccrueFeeToFeeCollector() (gas: 348494)
[PASS] testFillDAIToETH_WalletUserAndMMPMaker() (gas: 353211)
[PASS] testFillDAIToUSDT_EOAUserAndEOAMaker() (gas: 316767)
[PASS] testFillDAIToUSDT_EOAUserAndEOAMaker_WithOldEIP712Method() (gas: 317128)
[PASS] testFillETHToUSDT_EOAUserAndMMPMaker() (gas: 298497)
[PASS] testSetAllowanceCloseAllowance() (gas: 44003)
[PASS] testSetFeeCollector() (gas: 22512)
[PASS] testSetupAllowance() (gas: 71579)
[PASS] testSetupRFQ() (gas: 61321)
[PASS] testUpgradeSpender() (gas: 22512)
Test result: ok. 22 passed; 0 failed; finished in 22.36ms
    </code></pre>
</details>

Thank you very much!