### PR TITLE
refac: rfq, spender contracts changed to non named parameter type

### DIFF
--- a/contracts/RFQ.sol
+++ b/contracts/RFQ.sol
@@ -104,7 +104,7 @@ contract RFQ is IRFQ, StrategyBase, ReentrancyGuard, SignatureValidator, BaseLib
         // Set transaction as seen, PermanentStorage would throw error if transaction already seen.
         permStorage.setRFQTransactionSeen(vars.transactionHash);
 
-        return _settle({ _order: _order, _vars: vars, _makerAssetPermitSig: _makerAssetPermitSig, _takerAssetPermitSig: _takerAssetPermitSig });
+        return _settle(_order, vars, _makerAssetPermitSig, _takerAssetPermitSig);
     }
 
     function _emitFillOrder(
@@ -136,26 +136,26 @@ contract RFQ is IRFQ, StrategyBase, ReentrancyGuard, SignatureValidator, BaseLib
         bytes memory _takerAssetPermitSig
     ) internal returns (uint256) {
         // Declare the 'maker sends makerAsset to this contract' SpendWithPermit struct from _order parameter
-        SpenderLibEIP712.SpendWithPermit memory makerAssetPermit = SpenderLibEIP712.SpendWithPermit({
-            tokenAddr: _order.makerAssetAddr,
-            requester: address(this),
-            user: _order.makerAddr,
-            recipient: address(this),
-            amount: _order.makerAssetAmount,
-            actionHash: _vars.orderHash,
-            expiry: uint64(_order.deadline)
-        });
+        SpenderLibEIP712.SpendWithPermit memory makerAssetPermit = SpenderLibEIP712.SpendWithPermit(
+            _order.makerAssetAddr,
+            address(this),
+            _order.makerAddr,
+            address(this),
+            _order.makerAssetAmount,
+            _vars.orderHash,
+            uint64(_order.deadline)
+        );
 
         // Declare the 'taker sends takerAsset to this contract' SpendWithPermit struct from _order parameter
-        SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = SpenderLibEIP712.SpendWithPermit({
-            tokenAddr: _order.takerAssetAddr,
-            requester: address(this),
-            user: _order.takerAddr,
-            recipient: address(this),
-            amount: _order.takerAssetAmount,
-            actionHash: _vars.transactionHash,
-            expiry: uint64(_order.deadline)
-        });
+        SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = SpenderLibEIP712.SpendWithPermit(
+            _order.takerAssetAddr,
+            address(this),
+            _order.takerAddr,
+            address(this),
+            _order.takerAssetAmount,
+            _vars.transactionHash,
+            uint64(_order.deadline)
+        );
 
         // Transfer taker asset to maker
         if (address(weth) == _order.takerAssetAddr) {
@@ -165,7 +165,7 @@ contract RFQ is IRFQ, StrategyBase, ReentrancyGuard, SignatureValidator, BaseLib
             weth.transfer(_order.makerAddr, _order.takerAssetAmount);
         } else {
             // Transfer taker asset to this contract first,
-            spender.spendFromUserToWithPermit({ _params: takerAssetPermit, _spendWithPermitSig: _takerAssetPermitSig });
+            spender.spendFromUserToWithPermit(takerAssetPermit, _takerAssetPermitSig);
             // then transfer from this to maker.
             IERC20(_order.takerAssetAddr).safeTransfer(_order.makerAddr, _order.takerAssetAmount);
         }
@@ -178,7 +178,7 @@ contract RFQ is IRFQ, StrategyBase, ReentrancyGuard, SignatureValidator, BaseLib
         }
 
         // Transfer maker asset to this contract first
-        spender.spendFromUserToWithPermit({ _params: makerAssetPermit, _spendWithPermitSig: _makerAssetPermitSig });
+        spender.spendFromUserToWithPermit(makerAssetPermit, _makerAssetPermitSig);
 
         // Transfer maker asset less fee from this contract to receiver
         if (_order.makerAssetAddr == address(weth)) {

--- a/contracts/Spender.sol
+++ b/contracts/Spender.sol
@@ -205,16 +205,13 @@ contract Spender is ISpender, Ownable, BaseLibEIP712, SignatureValidator {
         require(_params.requester == msg.sender, "Spender: invalid requester address");
 
         // Validate spend with permit signature
-        bytes32 spendWithPermitHash = getEIP712Hash({ structHash: SpenderLibEIP712._getSpendWithPermitHash({ _spendWithPermit: _params }) });
+        bytes32 spendWithPermitHash = getEIP712Hash(SpenderLibEIP712._getSpendWithPermitHash(_params));
 
         // Validate spending is not replayed
         require(!spendingFulfilled[spendWithPermitHash], "Spender: Permit is already fulfilled");
         spendingFulfilled[spendWithPermitHash] = true;
 
-        require(
-            isValidSignature({ _signerAddress: _params.user, _hash: spendWithPermitHash, _data: bytes(""), _sig: _spendWithPermitSig }),
-            "Spender: Invalid permit signature"
-        );
+        require(isValidSignature(_params.user, spendWithPermitHash, bytes(""), _spendWithPermitSig), "Spender: Invalid permit signature");
 
         _transferTokenFromUserTo(_params.user, _params.tokenAddr, _params.recipient, _params.amount);
     }

--- a/contracts/SpenderSimulation.sol
+++ b/contracts/SpenderSimulation.sol
@@ -41,7 +41,7 @@ contract SpenderSimulation {
         external
         checkBlackList(_params.tokenAddr, _params.user)
     {
-        spender.spendFromUserToWithPermit({ _params: _params, _spendWithPermitSig: _spendWithPermitSig });
+        spender.spendFromUserToWithPermit(_params, _spendWithPermitSig);
 
         // All checks passed: revert with success reason string
         revert("SpenderSimulation: transfer simulation success");

--- a/contracts/test/RFQ.t.sol
+++ b/contracts/test/RFQ.t.sol
@@ -256,7 +256,7 @@ contract RFQTest is StrategySharedSetup {
             (
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
-            ) = _createSpenderPermitFromOrder({ defaultOrder: order });
+            ) = _createSpenderPermitFromOrder(order);
             bytes memory makerAssetPermitSig = _signSpendWithPermit(makerPrivateKey, makerAssetPermit, SignatureValidator.SignatureType.EIP712);
             bytes memory takerAssetPermitSig = _signSpendWithPermit(userPrivateKey, takerAssetPermit, SignatureValidator.SignatureType.EIP712);
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
@@ -275,7 +275,7 @@ contract RFQTest is StrategySharedSetup {
             (
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
-            ) = _createSpenderPermitFromOrder({ defaultOrder: order });
+            ) = _createSpenderPermitFromOrder(order);
             bytes memory makerAssetPermitSig = _signSpendWithPermit(makerPrivateKey, makerAssetPermit, SignatureValidator.SignatureType.EIP712);
             bytes memory takerAssetPermitSig = _signSpendWithPermit(userPrivateKey, takerAssetPermit, SignatureValidator.SignatureType.EIP712);
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
@@ -295,7 +295,7 @@ contract RFQTest is StrategySharedSetup {
             (
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
-            ) = _createSpenderPermitFromOrder({ defaultOrder: order });
+            ) = _createSpenderPermitFromOrder(order);
             // Sig with EIP712 type
             bytes memory makerAssetPermitSig = _signSpendWithPermit(makerPrivateKey, makerAssetPermit, SignatureValidator.SignatureType.EIP712);
             // Sig with WalletBytes32 type
@@ -316,7 +316,7 @@ contract RFQTest is StrategySharedSetup {
             (
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
-            ) = _createSpenderPermitFromOrder({ defaultOrder: order });
+            ) = _createSpenderPermitFromOrder(order);
             bytes memory makerAssetPermitSig = _signSpendWithPermit(makerPrivateKey, makerAssetPermit, SignatureValidator.SignatureType.EIP712);
             bytes memory takerAssetPermitSig = _signSpendWithPermit(userPrivateKey, takerAssetPermit, SignatureValidator.SignatureType.EIP712);
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
@@ -335,7 +335,7 @@ contract RFQTest is StrategySharedSetup {
             (
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
-            ) = _createSpenderPermitFromOrder({ defaultOrder: order });
+            ) = _createSpenderPermitFromOrder(order);
             bytes memory makerAssetPermitSig = _signSpendWithPermit(makerPrivateKey, makerAssetPermit, SignatureValidator.SignatureType.EIP712);
             bytes memory takerAssetPermitSig = _signSpendWithPermit(userPrivateKey, takerAssetPermit, SignatureValidator.SignatureType.EIP712);
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
@@ -363,7 +363,7 @@ contract RFQTest is StrategySharedSetup {
             (
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
-            ) = _createSpenderPermitFromOrder({ defaultOrder: order });
+            ) = _createSpenderPermitFromOrder(order);
             bytes memory makerAssetPermitSig = _signSpendWithPermit(makerPrivateKey, makerAssetPermit, SignatureValidator.SignatureType.EIP712);
             bytes memory takerAssetPermitSig = _signSpendWithPermit(userPrivateKey, takerAssetPermit, SignatureValidator.SignatureType.EIP712);
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
@@ -394,7 +394,7 @@ contract RFQTest is StrategySharedSetup {
             (
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
-            ) = _createSpenderPermitFromOrder({ defaultOrder: order });
+            ) = _createSpenderPermitFromOrder(order);
             // Sig with Wallet type
             bytes memory makerAssetPermitSig = _signSpendWithPermit(makerPrivateKey, makerAssetPermit, SignatureValidator.SignatureType.Wallet);
             // Sig with EIP712 type
@@ -428,7 +428,7 @@ contract RFQTest is StrategySharedSetup {
             (
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
-            ) = _createSpenderPermitFromOrder({ defaultOrder: order });
+            ) = _createSpenderPermitFromOrder(order);
             // Sig with Wallet type
             bytes memory makerAssetPermitSig = _signSpendWithPermit(makerPrivateKey, makerAssetPermit, SignatureValidator.SignatureType.Wallet);
             // Sig with WalletBytes32 type
@@ -459,7 +459,7 @@ contract RFQTest is StrategySharedSetup {
             (
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
-            ) = _createSpenderPermitFromOrder({ defaultOrder: order });
+            ) = _createSpenderPermitFromOrder(order);
             bytes memory makerAssetPermitSig = _signSpendWithPermit(makerPrivateKey, makerAssetPermit, SignatureValidator.SignatureType.EIP712);
             bytes memory takerAssetPermitSig = _signSpendWithPermit(userPrivateKey, takerAssetPermit, SignatureValidator.SignatureType.EIP712);
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
@@ -489,7 +489,7 @@ contract RFQTest is StrategySharedSetup {
             (
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
-            ) = _createSpenderPermitFromOrder({ defaultOrder: order });
+            ) = _createSpenderPermitFromOrder(order);
             bytes memory makerAssetPermitSig = _signSpendWithPermit(makerPrivateKey, makerAssetPermit, SignatureValidator.SignatureType.EIP712);
             bytes memory takerAssetPermitSig = _signSpendWithPermit(userPrivateKey, takerAssetPermit, SignatureValidator.SignatureType.EIP712);
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
@@ -533,7 +533,7 @@ contract RFQTest is StrategySharedSetup {
             (
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
-            ) = _createSpenderPermitFromOrder({ defaultOrder: order });
+            ) = _createSpenderPermitFromOrder(order);
             bytes memory makerAssetPermitSig = _signSpendWithPermit(makerPrivateKey, makerAssetPermit, SignatureValidator.SignatureType.EIP712);
             bytes memory takerAssetPermitSig = _signSpendWithPermit(userPrivateKey, takerAssetPermit, SignatureValidator.SignatureType.EIP712);
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
@@ -609,26 +609,26 @@ contract RFQTest is StrategySharedSetup {
         returns (SpenderLibEIP712.SpendWithPermit memory makerAssetPermit, SpenderLibEIP712.SpendWithPermit memory takerAssetPermit)
     {
         // maker (= mm) order: -> taker recive maker's token but except fee
-        makerAssetPermit = SpenderLibEIP712.SpendWithPermit({
-            tokenAddr: defaultOrder.makerAssetAddr,
-            requester: address(rfq),
-            user: defaultOrder.makerAddr,
-            recipient: address(rfq),
-            amount: defaultOrder.makerAssetAmount,
-            actionHash: RFQLibEIP712._getOrderHash(defaultOrder),
-            expiry: uint64(defaultOrder.deadline)
-        });
+        makerAssetPermit = SpenderLibEIP712.SpendWithPermit(
+            defaultOrder.makerAssetAddr,
+            address(rfq),
+            defaultOrder.makerAddr,
+            address(rfq),
+            defaultOrder.makerAssetAmount,
+            RFQLibEIP712._getOrderHash(defaultOrder),
+            uint64(defaultOrder.deadline)
+        );
 
         // taker (= user) transaction (= fill): -> maker recive taker's token totally
-        takerAssetPermit = SpenderLibEIP712.SpendWithPermit({
-            tokenAddr: defaultOrder.takerAssetAddr,
-            requester: address(rfq),
-            user: defaultOrder.takerAddr,
-            recipient: address(rfq),
-            amount: defaultOrder.takerAssetAmount,
-            actionHash: RFQLibEIP712._getTransactionHash(defaultOrder),
-            expiry: uint64(defaultOrder.deadline)
-        });
+        takerAssetPermit = SpenderLibEIP712.SpendWithPermit(
+            defaultOrder.takerAssetAddr,
+            address(rfq),
+            defaultOrder.takerAddr,
+            address(rfq),
+            defaultOrder.takerAssetAmount,
+            RFQLibEIP712._getTransactionHash(defaultOrder),
+            uint64(defaultOrder.deadline)
+        );
         return (makerAssetPermit, takerAssetPermit);
     }
 


### PR DESCRIPTION
RFQ, Spender contracts and their Foundry test contract changed to non named parameter type.

1. RFQ, Spender contracts and their Foundry test contract changed to non named parameter type.
2. Verify command (Not necessary):
```shell
tokenlon-contracts % DEPLOYED=false forge test -vvv --match-path 'contracts/test/Spender.t.sol'
tokenlon-contracts % DEPLOYED=false forge test -vvv --match-path 'contracts/test/RFQ.t.sol'
```