### PR TITLE
refac: rfq foundry test with named parameter

### DIFF
--- a/contracts/test/RFQ.t.sol
+++ b/contracts/test/RFQ.t.sol
@@ -443,7 +443,7 @@ contract RFQTest is StrategySharedSetup {
         bytes memory userSig = _signFill({ privateKey: userPrivateKey, order: order, sigType: SignatureValidator.SignatureType.EIP712 });
         bytes memory payload = _genFillPayload({ order: order, makerSig: makerSig, userSig: userSig });
 
-        _expectEvent({ order: order });
+        _expectEvent(order);
         vm.prank(user, user); // Only EOA
         userProxy.toRFQ(payload);
     }


### PR DESCRIPTION
# RFQ Foundry test with Named Parameter

1. Only change the RFQ Foundry test contract to named parameter style.
2. Only change the calling 'internal function' to named parameter style.
3. Verify command (Not necessary):
```shell
tokenlon-contracts % DEPLOYED=false forge test -vvv --match-path 'contracts/test/RFQ.t.sol'
```