### PR TITLE
refac: move the signSpendWithPermit function in foundry test

### DIFF
--- a/contracts/test/RFQ.t.sol
+++ b/contracts/test/RFQ.t.sol
@@ -258,8 +258,18 @@ contract RFQTest is StrategySharedSetup, Permit {
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
             ) = _createSpenderPermitFromOrder(order);
-            bytes memory makerAssetPermitSig = signSpendWithPermit(makerPrivateKey, makerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
-            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
+            bytes memory makerAssetPermitSig = signSpendWithPermit(
+                makerPrivateKey,
+                makerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
         }
         vm.expectRevert("RFQ: expired order");
@@ -277,8 +287,18 @@ contract RFQTest is StrategySharedSetup, Permit {
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
             ) = _createSpenderPermitFromOrder(order);
-            bytes memory makerAssetPermitSig = signSpendWithPermit(makerPrivateKey, makerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
-            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
+            bytes memory makerAssetPermitSig = signSpendWithPermit(
+                makerPrivateKey,
+                makerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
         }
         vm.expectRevert("RFQ: invalid user signature");
@@ -298,9 +318,19 @@ contract RFQTest is StrategySharedSetup, Permit {
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
             ) = _createSpenderPermitFromOrder(order);
             // Sig with EIP712 type
-            bytes memory makerAssetPermitSig = signSpendWithPermit(makerPrivateKey, makerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
+            bytes memory makerAssetPermitSig = signSpendWithPermit(
+                makerPrivateKey,
+                makerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
             // Sig with WalletBytes32 type
-            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender, SignatureValidator.SignatureType.WalletBytes32);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.WalletBytes32
+            );
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
         }
         vm.expectRevert(); // No revert string in this case
@@ -318,8 +348,18 @@ contract RFQTest is StrategySharedSetup, Permit {
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
             ) = _createSpenderPermitFromOrder(order);
-            bytes memory makerAssetPermitSig = signSpendWithPermit(makerPrivateKey, makerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
-            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
+            bytes memory makerAssetPermitSig = signSpendWithPermit(
+                makerPrivateKey,
+                makerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
         }
         vm.expectRevert("RFQ: invalid MM signature");
@@ -337,8 +377,18 @@ contract RFQTest is StrategySharedSetup, Permit {
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
             ) = _createSpenderPermitFromOrder(order);
-            bytes memory makerAssetPermitSig = signSpendWithPermit(makerPrivateKey, makerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
-            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
+            bytes memory makerAssetPermitSig = signSpendWithPermit(
+                makerPrivateKey,
+                makerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
         }
         BalanceSnapshot.Snapshot memory userTakerAsset = BalanceSnapshot.take(user, order.takerAssetAddr);
@@ -365,8 +415,18 @@ contract RFQTest is StrategySharedSetup, Permit {
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
             ) = _createSpenderPermitFromOrder(order);
-            bytes memory makerAssetPermitSig = signSpendWithPermit(makerPrivateKey, makerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
-            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
+            bytes memory makerAssetPermitSig = signSpendWithPermit(
+                makerPrivateKey,
+                makerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
         }
         BalanceSnapshot.Snapshot memory userTakerAsset = BalanceSnapshot.take(user, order.takerAssetAddr);
@@ -397,9 +457,19 @@ contract RFQTest is StrategySharedSetup, Permit {
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
             ) = _createSpenderPermitFromOrder(order);
             // Sig with Wallet type
-            bytes memory makerAssetPermitSig = signSpendWithPermit(makerPrivateKey, makerAssetPermit, spender, SignatureValidator.SignatureType.Wallet);
+            bytes memory makerAssetPermitSig = signSpendWithPermit(
+                makerPrivateKey,
+                makerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.Wallet
+            );
             // Sig with EIP712 type
-            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
         }
         BalanceSnapshot.Snapshot memory userTakerAsset = BalanceSnapshot.take(user, ETH_ADDRESS);
@@ -431,9 +501,19 @@ contract RFQTest is StrategySharedSetup, Permit {
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
             ) = _createSpenderPermitFromOrder(order);
             // Sig with Wallet type
-            bytes memory makerAssetPermitSig = signSpendWithPermit(makerPrivateKey, makerAssetPermit, spender, SignatureValidator.SignatureType.Wallet);
+            bytes memory makerAssetPermitSig = signSpendWithPermit(
+                makerPrivateKey,
+                makerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.Wallet
+            );
             // Sig with WalletBytes32 type
-            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender, SignatureValidator.SignatureType.WalletBytes32);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.WalletBytes32
+            );
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
         }
         BalanceSnapshot.Snapshot memory userWalletTakerAsset = BalanceSnapshot.take(address(mockERC1271Wallet), order.takerAssetAddr);
@@ -461,8 +541,18 @@ contract RFQTest is StrategySharedSetup, Permit {
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
             ) = _createSpenderPermitFromOrder(order);
-            bytes memory makerAssetPermitSig = signSpendWithPermit(makerPrivateKey, makerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
-            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
+            bytes memory makerAssetPermitSig = signSpendWithPermit(
+                makerPrivateKey,
+                makerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
         }
         BalanceSnapshot.Snapshot memory userTakerAsset = BalanceSnapshot.take(user, order.takerAssetAddr);
@@ -491,8 +581,18 @@ contract RFQTest is StrategySharedSetup, Permit {
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
             ) = _createSpenderPermitFromOrder(order);
-            bytes memory makerAssetPermitSig = signSpendWithPermit(makerPrivateKey, makerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
-            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
+            bytes memory makerAssetPermitSig = signSpendWithPermit(
+                makerPrivateKey,
+                makerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
         }
         vm.prank(user, user); // Only EOA
@@ -535,8 +635,18 @@ contract RFQTest is StrategySharedSetup, Permit {
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
             ) = _createSpenderPermitFromOrder(order);
-            bytes memory makerAssetPermitSig = signSpendWithPermit(makerPrivateKey, makerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
-            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
+            bytes memory makerAssetPermitSig = signSpendWithPermit(
+                makerPrivateKey,
+                makerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
         }
         _expectEvent(order);

--- a/contracts/test/RFQ.t.sol
+++ b/contracts/test/RFQ.t.sol
@@ -14,9 +14,10 @@ import "contracts-test/mocks/MockERC20.sol";
 import "contracts-test/mocks/MockWETH.sol";
 import "contracts-test/utils/BalanceSnapshot.sol";
 import "contracts-test/utils/StrategySharedSetup.sol";
+import "contracts-test/utils/Permit.sol";
 import { getEIP712Hash } from "contracts-test/utils/Sig.sol";
 
-contract RFQTest is StrategySharedSetup {
+contract RFQTest is StrategySharedSetup, Permit {
     using SafeMath for uint16;
     using SafeMath for uint256;
     using BalanceSnapshot for BalanceSnapshot.Snapshot;
@@ -257,8 +258,8 @@ contract RFQTest is StrategySharedSetup {
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
             ) = _createSpenderPermitFromOrder(order);
-            bytes memory makerAssetPermitSig = _signSpendWithPermit(makerPrivateKey, makerAssetPermit, SignatureValidator.SignatureType.EIP712);
-            bytes memory takerAssetPermitSig = _signSpendWithPermit(userPrivateKey, takerAssetPermit, SignatureValidator.SignatureType.EIP712);
+            bytes memory makerAssetPermitSig = signSpendWithPermit(makerPrivateKey, makerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
         }
         vm.expectRevert("RFQ: expired order");
@@ -276,8 +277,8 @@ contract RFQTest is StrategySharedSetup {
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
             ) = _createSpenderPermitFromOrder(order);
-            bytes memory makerAssetPermitSig = _signSpendWithPermit(makerPrivateKey, makerAssetPermit, SignatureValidator.SignatureType.EIP712);
-            bytes memory takerAssetPermitSig = _signSpendWithPermit(userPrivateKey, takerAssetPermit, SignatureValidator.SignatureType.EIP712);
+            bytes memory makerAssetPermitSig = signSpendWithPermit(makerPrivateKey, makerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
         }
         vm.expectRevert("RFQ: invalid user signature");
@@ -297,9 +298,9 @@ contract RFQTest is StrategySharedSetup {
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
             ) = _createSpenderPermitFromOrder(order);
             // Sig with EIP712 type
-            bytes memory makerAssetPermitSig = _signSpendWithPermit(makerPrivateKey, makerAssetPermit, SignatureValidator.SignatureType.EIP712);
+            bytes memory makerAssetPermitSig = signSpendWithPermit(makerPrivateKey, makerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
             // Sig with WalletBytes32 type
-            bytes memory takerAssetPermitSig = _signSpendWithPermit(userPrivateKey, takerAssetPermit, SignatureValidator.SignatureType.WalletBytes32);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender, SignatureValidator.SignatureType.WalletBytes32);
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
         }
         vm.expectRevert(); // No revert string in this case
@@ -317,8 +318,8 @@ contract RFQTest is StrategySharedSetup {
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
             ) = _createSpenderPermitFromOrder(order);
-            bytes memory makerAssetPermitSig = _signSpendWithPermit(makerPrivateKey, makerAssetPermit, SignatureValidator.SignatureType.EIP712);
-            bytes memory takerAssetPermitSig = _signSpendWithPermit(userPrivateKey, takerAssetPermit, SignatureValidator.SignatureType.EIP712);
+            bytes memory makerAssetPermitSig = signSpendWithPermit(makerPrivateKey, makerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
         }
         vm.expectRevert("RFQ: invalid MM signature");
@@ -336,8 +337,8 @@ contract RFQTest is StrategySharedSetup {
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
             ) = _createSpenderPermitFromOrder(order);
-            bytes memory makerAssetPermitSig = _signSpendWithPermit(makerPrivateKey, makerAssetPermit, SignatureValidator.SignatureType.EIP712);
-            bytes memory takerAssetPermitSig = _signSpendWithPermit(userPrivateKey, takerAssetPermit, SignatureValidator.SignatureType.EIP712);
+            bytes memory makerAssetPermitSig = signSpendWithPermit(makerPrivateKey, makerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
         }
         BalanceSnapshot.Snapshot memory userTakerAsset = BalanceSnapshot.take(user, order.takerAssetAddr);
@@ -364,8 +365,8 @@ contract RFQTest is StrategySharedSetup {
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
             ) = _createSpenderPermitFromOrder(order);
-            bytes memory makerAssetPermitSig = _signSpendWithPermit(makerPrivateKey, makerAssetPermit, SignatureValidator.SignatureType.EIP712);
-            bytes memory takerAssetPermitSig = _signSpendWithPermit(userPrivateKey, takerAssetPermit, SignatureValidator.SignatureType.EIP712);
+            bytes memory makerAssetPermitSig = signSpendWithPermit(makerPrivateKey, makerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
         }
         BalanceSnapshot.Snapshot memory userTakerAsset = BalanceSnapshot.take(user, order.takerAssetAddr);
@@ -396,9 +397,9 @@ contract RFQTest is StrategySharedSetup {
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
             ) = _createSpenderPermitFromOrder(order);
             // Sig with Wallet type
-            bytes memory makerAssetPermitSig = _signSpendWithPermit(makerPrivateKey, makerAssetPermit, SignatureValidator.SignatureType.Wallet);
+            bytes memory makerAssetPermitSig = signSpendWithPermit(makerPrivateKey, makerAssetPermit, spender, SignatureValidator.SignatureType.Wallet);
             // Sig with EIP712 type
-            bytes memory takerAssetPermitSig = _signSpendWithPermit(userPrivateKey, takerAssetPermit, SignatureValidator.SignatureType.EIP712);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
         }
         BalanceSnapshot.Snapshot memory userTakerAsset = BalanceSnapshot.take(user, ETH_ADDRESS);
@@ -430,9 +431,9 @@ contract RFQTest is StrategySharedSetup {
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
             ) = _createSpenderPermitFromOrder(order);
             // Sig with Wallet type
-            bytes memory makerAssetPermitSig = _signSpendWithPermit(makerPrivateKey, makerAssetPermit, SignatureValidator.SignatureType.Wallet);
+            bytes memory makerAssetPermitSig = signSpendWithPermit(makerPrivateKey, makerAssetPermit, spender, SignatureValidator.SignatureType.Wallet);
             // Sig with WalletBytes32 type
-            bytes memory takerAssetPermitSig = _signSpendWithPermit(userPrivateKey, takerAssetPermit, SignatureValidator.SignatureType.WalletBytes32);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender, SignatureValidator.SignatureType.WalletBytes32);
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
         }
         BalanceSnapshot.Snapshot memory userWalletTakerAsset = BalanceSnapshot.take(address(mockERC1271Wallet), order.takerAssetAddr);
@@ -460,8 +461,8 @@ contract RFQTest is StrategySharedSetup {
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
             ) = _createSpenderPermitFromOrder(order);
-            bytes memory makerAssetPermitSig = _signSpendWithPermit(makerPrivateKey, makerAssetPermit, SignatureValidator.SignatureType.EIP712);
-            bytes memory takerAssetPermitSig = _signSpendWithPermit(userPrivateKey, takerAssetPermit, SignatureValidator.SignatureType.EIP712);
+            bytes memory makerAssetPermitSig = signSpendWithPermit(makerPrivateKey, makerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
         }
         BalanceSnapshot.Snapshot memory userTakerAsset = BalanceSnapshot.take(user, order.takerAssetAddr);
@@ -490,8 +491,8 @@ contract RFQTest is StrategySharedSetup {
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
             ) = _createSpenderPermitFromOrder(order);
-            bytes memory makerAssetPermitSig = _signSpendWithPermit(makerPrivateKey, makerAssetPermit, SignatureValidator.SignatureType.EIP712);
-            bytes memory takerAssetPermitSig = _signSpendWithPermit(userPrivateKey, takerAssetPermit, SignatureValidator.SignatureType.EIP712);
+            bytes memory makerAssetPermitSig = signSpendWithPermit(makerPrivateKey, makerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
         }
         vm.prank(user, user); // Only EOA
@@ -534,8 +535,8 @@ contract RFQTest is StrategySharedSetup {
                 SpenderLibEIP712.SpendWithPermit memory makerAssetPermit,
                 SpenderLibEIP712.SpendWithPermit memory takerAssetPermit
             ) = _createSpenderPermitFromOrder(order);
-            bytes memory makerAssetPermitSig = _signSpendWithPermit(makerPrivateKey, makerAssetPermit, SignatureValidator.SignatureType.EIP712);
-            bytes memory takerAssetPermitSig = _signSpendWithPermit(userPrivateKey, takerAssetPermit, SignatureValidator.SignatureType.EIP712);
+            bytes memory makerAssetPermitSig = signSpendWithPermit(makerPrivateKey, makerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender, SignatureValidator.SignatureType.EIP712);
             payload = _genFillPayload(order, makerSig, userSig, makerAssetPermitSig, takerAssetPermitSig);
         }
         _expectEvent(order);
@@ -630,40 +631,6 @@ contract RFQTest is StrategySharedSetup {
             uint64(defaultOrder.deadline)
         );
         return (makerAssetPermit, takerAssetPermit);
-    }
-
-    function _getEIP712Hash(bytes32 structHash) internal view returns (bytes32) {
-        string memory EIP191_HEADER = "\x19\x01";
-        bytes32 EIP712_DOMAIN_SEPARATOR = spender.EIP712_DOMAIN_SEPARATOR();
-        return keccak256(abi.encodePacked(EIP191_HEADER, EIP712_DOMAIN_SEPARATOR, structHash));
-    }
-
-    function _signSpendWithPermit(
-        uint256 privateKey,
-        SpenderLibEIP712.SpendWithPermit memory spendWithPermit,
-        SignatureValidator.SignatureType sigType
-    ) internal returns (bytes memory sig) {
-        uint256 SPEND_WITH_PERMIT_TYPEHASH = 0x52718c957261b99fd72e63478d85d1267cdc812e8249f5a2623566c1818e1ed0;
-        bytes32 structHash = keccak256(
-            abi.encode(
-                SPEND_WITH_PERMIT_TYPEHASH,
-                spendWithPermit.tokenAddr,
-                spendWithPermit.requester,
-                spendWithPermit.user,
-                spendWithPermit.recipient,
-                spendWithPermit.amount,
-                spendWithPermit.actionHash,
-                spendWithPermit.expiry
-            )
-        );
-        bytes32 spendWithPermitHash = _getEIP712Hash(structHash);
-        if (sigType == SignatureValidator.SignatureType.Wallet) {
-            (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, ECDSA.toEthSignedMessageHash(spendWithPermitHash));
-            sig = abi.encodePacked(r, s, v, uint8(sigType)); // new signature format
-        } else {
-            (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, spendWithPermitHash);
-            sig = abi.encodePacked(r, s, v, uint8(sigType)); // new signature format
-        }
     }
 
     function _genFillPayload(

--- a/contracts/test/Spender.t.sol
+++ b/contracts/test/Spender.t.sol
@@ -325,7 +325,7 @@ contract SpenderTest is BalanceUtil, Permit {
     function testCannotSpendFromUserToWithPermitWithExpiredPermit() public {
         SpenderLibEIP712.SpendWithPermit memory spendWithPermit = DEFAULT_SPEND_WITH_PERMIT;
         spendWithPermit.expiry = uint64(block.timestamp - 1); // Timestamp expired
-        bytes memory sig = signSpendWithPermit(userPrivateKey, spendWithPermit, spender, SignatureValidator.SignatureType.EIP712);
+        bytes memory sig = signSpendWithPermit(userPrivateKey, spendWithPermit, spender.EIP712_DOMAIN_SEPARATOR(), SignatureValidator.SignatureType.EIP712);
 
         vm.expectRevert("Spender: Permit is expired");
         spender.spendFromUserToWithPermit(spendWithPermit, sig);
@@ -334,7 +334,7 @@ contract SpenderTest is BalanceUtil, Permit {
     function testCannotSpendFromUserToWithPermitWithWrongRequester() public {
         SpenderLibEIP712.SpendWithPermit memory spendWithPermit = DEFAULT_SPEND_WITH_PERMIT;
         spendWithPermit.requester = unauthorized; // Wrong requester address
-        bytes memory sig = signSpendWithPermit(userPrivateKey, spendWithPermit, spender, SignatureValidator.SignatureType.EIP712);
+        bytes memory sig = signSpendWithPermit(userPrivateKey, spendWithPermit, spender.EIP712_DOMAIN_SEPARATOR(), SignatureValidator.SignatureType.EIP712);
 
         vm.expectRevert("Spender: invalid requester address");
         spender.spendFromUserToWithPermit(spendWithPermit, sig);
@@ -342,7 +342,7 @@ contract SpenderTest is BalanceUtil, Permit {
 
     function testCannotSpendFromUserToWithPermitByWrongSigner() public {
         SpenderLibEIP712.SpendWithPermit memory spendWithPermit = DEFAULT_SPEND_WITH_PERMIT;
-        bytes memory sig = signSpendWithPermit(otherPrivateKey, spendWithPermit, spender, SignatureValidator.SignatureType.EIP712); // Wrong signer
+        bytes memory sig = signSpendWithPermit(otherPrivateKey, spendWithPermit, spender.EIP712_DOMAIN_SEPARATOR(), SignatureValidator.SignatureType.EIP712); // Wrong signer
 
         vm.expectRevert("Spender: Invalid permit signature");
         spender.spendFromUserToWithPermit(spendWithPermit, sig);
@@ -350,7 +350,7 @@ contract SpenderTest is BalanceUtil, Permit {
 
     function testCannotSpendFromUserToWithPermitWithWrongRecipient() public {
         SpenderLibEIP712.SpendWithPermit memory spendWithPermit = DEFAULT_SPEND_WITH_PERMIT;
-        bytes memory sig = signSpendWithPermit(userPrivateKey, spendWithPermit, spender, SignatureValidator.SignatureType.EIP712);
+        bytes memory sig = signSpendWithPermit(userPrivateKey, spendWithPermit, spender.EIP712_DOMAIN_SEPARATOR(), SignatureValidator.SignatureType.EIP712);
 
         vm.expectRevert("Spender: Invalid permit signature");
         spendWithPermit.recipient = unauthorized; // recipient is different from signed
@@ -359,7 +359,7 @@ contract SpenderTest is BalanceUtil, Permit {
 
     function testCannotSpendFromUserToWithPermitWithWrongToken() public {
         SpenderLibEIP712.SpendWithPermit memory spendWithPermit = DEFAULT_SPEND_WITH_PERMIT;
-        bytes memory sig = signSpendWithPermit(userPrivateKey, spendWithPermit, spender, SignatureValidator.SignatureType.EIP712);
+        bytes memory sig = signSpendWithPermit(userPrivateKey, spendWithPermit, spender.EIP712_DOMAIN_SEPARATOR(), SignatureValidator.SignatureType.EIP712);
 
         vm.expectRevert("Spender: Invalid permit signature");
         spendWithPermit.tokenAddr = unauthorized; // tokenAddr is different from signed
@@ -368,7 +368,7 @@ contract SpenderTest is BalanceUtil, Permit {
 
     function testCannotSpendFromUserToWithPermitWithWrongAmount() public {
         SpenderLibEIP712.SpendWithPermit memory spendWithPermit = DEFAULT_SPEND_WITH_PERMIT;
-        bytes memory sig = signSpendWithPermit(userPrivateKey, spendWithPermit, spender, SignatureValidator.SignatureType.EIP712);
+        bytes memory sig = signSpendWithPermit(userPrivateKey, spendWithPermit, spender.EIP712_DOMAIN_SEPARATOR(), SignatureValidator.SignatureType.EIP712);
 
         vm.expectRevert("Spender: Invalid permit signature");
         spendWithPermit.amount = spendWithPermit.amount + 1; // amount is different from signed
@@ -377,7 +377,7 @@ contract SpenderTest is BalanceUtil, Permit {
 
     function testCannotSpendFromUserToWithPermitByNotAuthorized() public {
         SpenderLibEIP712.SpendWithPermit memory spendWithPermit = DEFAULT_SPEND_WITH_PERMIT;
-        bytes memory sig = signSpendWithPermit(userPrivateKey, spendWithPermit, spender, SignatureValidator.SignatureType.EIP712);
+        bytes memory sig = signSpendWithPermit(userPrivateKey, spendWithPermit, spender.EIP712_DOMAIN_SEPARATOR(), SignatureValidator.SignatureType.EIP712);
 
         vm.expectRevert("Spender: not authorized");
         vm.prank(unauthorized); // Only authorized strategy contracts and owner
@@ -391,7 +391,7 @@ contract SpenderTest is BalanceUtil, Permit {
         blacklistBool[0] = true;
         spender.blacklist(blacklistAddress, blacklistBool); // Set lon to black list by owner (this contract)
         SpenderLibEIP712.SpendWithPermit memory spendWithPermit = DEFAULT_SPEND_WITH_PERMIT;
-        bytes memory sig = signSpendWithPermit(userPrivateKey, spendWithPermit, spender, SignatureValidator.SignatureType.EIP712);
+        bytes memory sig = signSpendWithPermit(userPrivateKey, spendWithPermit, spender.EIP712_DOMAIN_SEPARATOR(), SignatureValidator.SignatureType.EIP712);
 
         vm.expectRevert("Spender: token is blacklisted");
         spender.spendFromUserToWithPermit(spendWithPermit, sig);
@@ -399,7 +399,7 @@ contract SpenderTest is BalanceUtil, Permit {
 
     function testCannotSpendFromUserToWithPermitWithSamePermit() public {
         SpenderLibEIP712.SpendWithPermit memory spendWithPermit = DEFAULT_SPEND_WITH_PERMIT;
-        bytes memory sig = signSpendWithPermit(userPrivateKey, spendWithPermit, spender, SignatureValidator.SignatureType.EIP712);
+        bytes memory sig = signSpendWithPermit(userPrivateKey, spendWithPermit, spender.EIP712_DOMAIN_SEPARATOR(), SignatureValidator.SignatureType.EIP712);
         spender.spendFromUserToWithPermit(spendWithPermit, sig);
 
         vm.expectRevert("Spender: Permit is already fulfilled");
@@ -409,7 +409,7 @@ contract SpenderTest is BalanceUtil, Permit {
     function testSpendFromUserToWithPermit() public {
         BalanceSnapshot.Snapshot memory recipientLon = BalanceSnapshot.take(recipient, address(lon));
         SpenderLibEIP712.SpendWithPermit memory spendWithPermit = DEFAULT_SPEND_WITH_PERMIT;
-        bytes memory sig = signSpendWithPermit(userPrivateKey, spendWithPermit, spender, SignatureValidator.SignatureType.EIP712);
+        bytes memory sig = signSpendWithPermit(userPrivateKey, spendWithPermit, spender.EIP712_DOMAIN_SEPARATOR(), SignatureValidator.SignatureType.EIP712);
         spender.spendFromUserToWithPermit(spendWithPermit, sig);
 
         recipientLon.assertChange(int256(spendWithPermit.amount)); // Confirm amount of tokens received
@@ -423,7 +423,7 @@ contract SpenderTest is BalanceUtil, Permit {
         SpenderLibEIP712.SpendWithPermit memory spendWithPermit = DEFAULT_SPEND_WITH_PERMIT;
         // Set the requester address to spenderSimulation contract
         spendWithPermit.requester = address(spenderSimulation);
-        bytes memory sig = signSpendWithPermit(userPrivateKey, spendWithPermit, spender, SignatureValidator.SignatureType.EIP712);
+        bytes memory sig = signSpendWithPermit(userPrivateKey, spendWithPermit, spender.EIP712_DOMAIN_SEPARATOR(), SignatureValidator.SignatureType.EIP712);
         // Set address of spenderSimulation to be removed from authorization list of spender,
         // and spenderSimulation can not execute spender.spendFromUserToWithPermit() function.
         address[] memory spenderSimulationAddr = new address[](1);
@@ -438,7 +438,7 @@ contract SpenderTest is BalanceUtil, Permit {
         SpenderLibEIP712.SpendWithPermit memory spendWithPermit = DEFAULT_SPEND_WITH_PERMIT;
         // Set the requester address to spenderSimulation contract
         spendWithPermit.requester = address(spenderSimulation);
-        bytes memory sig = signSpendWithPermit(userPrivateKey, spendWithPermit, spender, SignatureValidator.SignatureType.EIP712);
+        bytes memory sig = signSpendWithPermit(userPrivateKey, spendWithPermit, spender.EIP712_DOMAIN_SEPARATOR(), SignatureValidator.SignatureType.EIP712);
 
         vm.expectRevert("SpenderSimulation: transfer simulation success");
         spenderSimulation.simulate(spendWithPermit, sig);

--- a/contracts/test/utils/Permit.sol
+++ b/contracts/test/utils/Permit.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.7.6;
+pragma abicoder v2;
+
+import "@openzeppelin/contracts/cryptography/ECDSA.sol";
+import "forge-std/Test.sol";
+import "contracts/Spender.sol";
+import "contracts/utils/SpenderLibEIP712.sol";
+import "contracts/utils/SignatureValidator.sol";
+import { getEIP712Hash } from "contracts-test/utils/Sig.sol";
+
+contract Permit is Test {
+    function signSpendWithPermit(
+        uint256 privateKey,
+        SpenderLibEIP712.SpendWithPermit memory spendWithPermit,
+        Spender spenderContract,
+        SignatureValidator.SignatureType sigType
+    ) internal returns (bytes memory sig) {
+        uint256 SPEND_WITH_PERMIT_TYPEHASH = 0x52718c957261b99fd72e63478d85d1267cdc812e8249f5a2623566c1818e1ed0;
+        bytes32 structHash = keccak256(
+            abi.encode(
+                SPEND_WITH_PERMIT_TYPEHASH,
+                spendWithPermit.tokenAddr,
+                spendWithPermit.requester,
+                spendWithPermit.user,
+                spendWithPermit.recipient,
+                spendWithPermit.amount,
+                spendWithPermit.actionHash,
+                spendWithPermit.expiry
+            )
+        );
+        bytes32 spendWithPermitHash = getEIP712Hash(spenderContract.EIP712_DOMAIN_SEPARATOR(), structHash); //_getEIP712Hash(structHash);
+        if (sigType == SignatureValidator.SignatureType.Wallet) {
+            (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, ECDSA.toEthSignedMessageHash(spendWithPermitHash));
+            sig = abi.encodePacked(r, s, v, uint8(sigType)); // new signature format
+        } else {
+            (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, spendWithPermitHash);
+            sig = abi.encodePacked(r, s, v, uint8(sigType)); // new signature format
+        }
+    }
+}

--- a/contracts/test/utils/Permit.sol
+++ b/contracts/test/utils/Permit.sol
@@ -30,12 +30,14 @@ contract Permit is Test {
             )
         );
         bytes32 spendWithPermitHash = getEIP712Hash(domainSeparator, structHash);
-        if (sigType == SignatureValidator.SignatureType.Wallet) {
+        if (sigType == SignatureValidator.SignatureType.EIP712 || sigType == SignatureValidator.SignatureType.WalletBytes32) {
+            (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, spendWithPermitHash);
+            sig = abi.encodePacked(r, s, v, uint8(sigType)); // new signature format
+        } else if (sigType == SignatureValidator.SignatureType.Wallet) {
             (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, ECDSA.toEthSignedMessageHash(spendWithPermitHash));
             sig = abi.encodePacked(r, s, v, uint8(sigType)); // new signature format
         } else {
-            (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, spendWithPermitHash);
-            sig = abi.encodePacked(r, s, v, uint8(sigType)); // new signature format
+            revert("Invalid signature type");
         }
     }
 }

--- a/contracts/test/utils/Permit.sol
+++ b/contracts/test/utils/Permit.sol
@@ -13,7 +13,7 @@ contract Permit is Test {
     function signSpendWithPermit(
         uint256 privateKey,
         SpenderLibEIP712.SpendWithPermit memory spendWithPermit,
-        Spender spenderContract,
+        bytes32 domainSeparator,
         SignatureValidator.SignatureType sigType
     ) internal returns (bytes memory sig) {
         uint256 SPEND_WITH_PERMIT_TYPEHASH = 0x52718c957261b99fd72e63478d85d1267cdc812e8249f5a2623566c1818e1ed0;
@@ -29,7 +29,7 @@ contract Permit is Test {
                 spendWithPermit.expiry
             )
         );
-        bytes32 spendWithPermitHash = getEIP712Hash(spenderContract.EIP712_DOMAIN_SEPARATOR(), structHash); //_getEIP712Hash(structHash);
+        bytes32 spendWithPermitHash = getEIP712Hash(domainSeparator, structHash);
         if (sigType == SignatureValidator.SignatureType.Wallet) {
             (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, ECDSA.toEthSignedMessageHash(spendWithPermitHash));
             sig = abi.encodePacked(r, s, v, uint8(sigType)); // new signature format


### PR DESCRIPTION
1. Centralize the signSpendWithPermit function into Permit.sol to reduce the amount of code.
2. Currently only the RFQ.t.sol and Spender.t.sol files are modified.
3. Verify command:
```shell
tokenlon-contracts % DEPLOYED=false forge test -vvv --match-path 'contracts/test/Spender.t.sol'
tokenlon-contracts % DEPLOYED=false forge test -vvv --match-path 'contracts/test/RFQ.t.sol'
```