### PR TITLE
Amm with spender permit

### DIFF
--- a/contracts/AMMWrapper.sol
+++ b/contracts/AMMWrapper.sol
@@ -115,12 +115,12 @@ contract AMMWrapper is IAMMWrapper, StrategyBase, ReentrancyGuard, BaseLibEIP712
      *                   External functions                      *
      *************************************************************/
     function trade(
-        AMMLibEIP712.Order calldata order,
+        AMMLibEIP712.Order calldata _order,
         uint256 _feeFactor,
         bytes calldata _sig,
         bytes calldata _takerAssetPermitSig
     ) external payable override nonReentrant onlyUserProxy returns (uint256) {
-        require(order.deadline >= block.timestamp, "AMMWrapper: expired order");
+        require(_order.deadline >= block.timestamp, "AMMWrapper: expired order");
 
         // These variables are copied straight from function parameters and
         // used to bypass stack too deep error.
@@ -134,36 +134,36 @@ contract AMMWrapper is IAMMWrapper, StrategyBase, ReentrancyGuard, BaseLibEIP712
         }
 
         // Assign trade vairables
-        internalTxData.fromEth = (order.takerAssetAddr == LibConstant.ZERO_ADDRESS || order.takerAssetAddr == LibConstant.ETH_ADDRESS);
-        internalTxData.toEth = (order.makerAssetAddr == LibConstant.ZERO_ADDRESS || order.makerAssetAddr == LibConstant.ETH_ADDRESS);
-        if (_isCurve(order.makerAddr)) {
+        internalTxData.fromEth = (_order.takerAssetAddr == LibConstant.ZERO_ADDRESS || _order.takerAssetAddr == LibConstant.ETH_ADDRESS);
+        internalTxData.toEth = (_order.makerAssetAddr == LibConstant.ZERO_ADDRESS || _order.makerAssetAddr == LibConstant.ETH_ADDRESS);
+        if (_isCurve(_order.makerAddr)) {
             // PermanetStorage can recognize `ETH_ADDRESS` but not `ZERO_ADDRESS`.
             // Convert it to `ETH_ADDRESS` as passed in `order.takerAssetAddr` or `order.makerAssetAddr` might be `ZERO_ADDRESS`.
-            internalTxData.takerAssetInternalAddr = internalTxData.fromEth ? LibConstant.ETH_ADDRESS : order.takerAssetAddr;
-            internalTxData.makerAssetInternalAddr = internalTxData.toEth ? LibConstant.ETH_ADDRESS : order.makerAssetAddr;
+            internalTxData.takerAssetInternalAddr = internalTxData.fromEth ? LibConstant.ETH_ADDRESS : _order.takerAssetAddr;
+            internalTxData.makerAssetInternalAddr = internalTxData.toEth ? LibConstant.ETH_ADDRESS : _order.makerAssetAddr;
         } else {
-            internalTxData.takerAssetInternalAddr = internalTxData.fromEth ? address(weth) : order.takerAssetAddr;
-            internalTxData.makerAssetInternalAddr = internalTxData.toEth ? address(weth) : order.makerAssetAddr;
+            internalTxData.takerAssetInternalAddr = internalTxData.fromEth ? address(weth) : _order.takerAssetAddr;
+            internalTxData.makerAssetInternalAddr = internalTxData.toEth ? address(weth) : _order.makerAssetAddr;
         }
 
-        txMetaData.transactionHash = _verify(order, _sig);
+        txMetaData.transactionHash = _verify(_order, _sig);
 
-        _prepare(order, internalTxData, _takerAssetPermitSig);
+        _prepare(_order, internalTxData, _takerAssetPermitSig);
 
         {
             // Set min amount for swap = _order.makerAssetAmount * (10000 / (10000 - feeFactor))
-            uint256 swapMinOutAmount = order.makerAssetAmount.mul(LibConstant.BPS_MAX).div(LibConstant.BPS_MAX.sub(txMetaData.feeFactor));
-            (txMetaData.source, txMetaData.receivedAmount) = _swap(order, internalTxData, swapMinOutAmount);
+            uint256 swapMinOutAmount = _order.makerAssetAmount.mul(LibConstant.BPS_MAX).div(LibConstant.BPS_MAX.sub(txMetaData.feeFactor));
+            (txMetaData.source, txMetaData.receivedAmount) = _swap(_order, internalTxData, swapMinOutAmount);
 
             // Settle
             // Calculate fee using actually received from swap
             uint256 actualFee = txMetaData.receivedAmount.mul(txMetaData.feeFactor).div(LibConstant.BPS_MAX);
             txMetaData.settleAmount = txMetaData.receivedAmount.sub(actualFee);
-            require(txMetaData.settleAmount >= order.makerAssetAmount, "AMMWrapper: insufficient maker output");
-            _settle(order, internalTxData, txMetaData.settleAmount, actualFee);
+            require(txMetaData.settleAmount >= _order.makerAssetAmount, "AMMWrapper: insufficient maker output");
+            _settle(_order, internalTxData, txMetaData.settleAmount, actualFee);
         }
 
-        emitSwappedEvent(order, txMetaData);
+        emitSwappedEvent(_order, txMetaData);
         return txMetaData.settleAmount;
     }
 

--- a/contracts/AMMWrapper.sol
+++ b/contracts/AMMWrapper.sol
@@ -231,11 +231,11 @@ contract AMMWrapper is IAMMWrapper, StrategyBase, ReentrancyGuard, BaseLibEIP712
             // Transfer other ERC20 tokens to this contract
             SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = SpenderLibEIP712.SpendWithPermit(
                 _order.takerAssetAddr,
-                address(this),
+                address(this), // requester
                 _order.userAddr,
-                address(this),
+                address(this), // recipient
                 _order.takerAssetAmount,
-                AMMLibEIP712._getOrderHash(_order),
+                AMMLibEIP712._getOrderHash(_order), // actionHash
                 uint64(_order.deadline)
             );
             spender.spendFromUserToWithPermit(takerAssetPermit, _takerAssetPermitSig);

--- a/contracts/AMMWrapper.sol
+++ b/contracts/AMMWrapper.sol
@@ -229,15 +229,15 @@ contract AMMWrapper is IAMMWrapper, StrategyBase, ReentrancyGuard, BaseLibEIP712
             }
         } else {
             // Transfer other ERC20 tokens to this contract
-            SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = SpenderLibEIP712.SpendWithPermit(
-                _order.takerAssetAddr,
-                address(this), // requester
-                _order.userAddr,
-                address(this), // recipient
-                _order.takerAssetAmount,
-                AMMLibEIP712._getOrderHash(_order), // actionHash
-                uint64(_order.deadline)
-            );
+            SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = SpenderLibEIP712.SpendWithPermit({
+                tokenAddr: _order.takerAssetAddr,
+                requester: address(this),
+                user: _order.userAddr,
+                recipient: address(this),
+                amount: _order.takerAssetAmount,
+                actionHash: AMMLibEIP712._getOrderHash(_order),
+                expiry: uint64(_order.deadline)
+            });
             spender.spendFromUserToWithPermit(takerAssetPermit, _takerAssetPermitSig);
         }
     }

--- a/contracts/AMMWrapper.sol
+++ b/contracts/AMMWrapper.sol
@@ -212,7 +212,7 @@ contract AMMWrapper is IAMMWrapper, StrategyBase, ReentrancyGuard, BaseLibEIP712
 
     /**
      * @dev internal function of `trade`.
-     * It verifies the spender permission and transfer assets from the user to this contract.
+     * It transfers assets from the taker to this contract with taker's permission.
      */
     function _transferTakerAssetToAMM(
         AMMLibEIP712.Order memory _order,

--- a/contracts/AMMWrapperWithPath.sol
+++ b/contracts/AMMWrapperWithPath.sol
@@ -82,7 +82,7 @@ contract AMMWrapperWithPath is IAMMWrapperWithPath, AMMWrapper {
 
         txMetaData.transactionHash = _verify(_params.order, _params.sig);
 
-        _prepare(_params.order, internalTxData, _params.takerAssetPermitSig);
+        _transferTakerAssetToAMM(_params.order, internalTxData, _params.takerAssetPermitSig);
 
         {
             // Set min amount for swap = _order.makerAssetAmount * (10000 / (10000 - feeFactor))

--- a/contracts/AMMWrapperWithPath.sol
+++ b/contracts/AMMWrapperWithPath.sol
@@ -51,59 +51,53 @@ contract AMMWrapperWithPath is IAMMWrapperWithPath, AMMWrapper {
      *                   External functions                      *
      *************************************************************/
 
-    function trade(
-        AMMLibEIP712.Order calldata _order,
-        uint256 _feeFactor,
-        bytes calldata _sig,
-        bytes calldata _makerSpecificData,
-        address[] calldata _path
-    ) external payable override nonReentrant onlyUserProxy returns (uint256) {
-        require(_order.deadline >= block.timestamp, "AMMWrapper: expired order");
+    function trade(IAMMWrapperWithPath.TradeWithPathParams calldata _params) external payable override nonReentrant onlyUserProxy returns (uint256) {
+        require(_params.order.deadline >= block.timestamp, "AMMWrapper: expired order");
 
         // These variables are copied straight from function parameters and
         // used to bypass stack too deep error.
         TxMetaData memory txMetaData;
         InternalTxData memory internalTxData;
-        txMetaData.feeFactor = uint16(_feeFactor);
+        txMetaData.feeFactor = uint16(_params.feeFactor);
         txMetaData.relayed = permStorage.isRelayerValid(tx.origin);
-        internalTxData.makerSpecificData = _makerSpecificData;
-        internalTxData.path = _path;
+        internalTxData.makerSpecificData = _params.makerSpecificData;
+        internalTxData.path = _params.path;
         if (!txMetaData.relayed) {
             // overwrite feeFactor with defaultFeeFactor if not from valid relayer
             txMetaData.feeFactor = defaultFeeFactor;
         }
 
         // Assign trade vairables
-        internalTxData.fromEth = (_order.takerAssetAddr == LibConstant.ZERO_ADDRESS || _order.takerAssetAddr == LibConstant.ETH_ADDRESS);
-        internalTxData.toEth = (_order.makerAssetAddr == LibConstant.ZERO_ADDRESS || _order.makerAssetAddr == LibConstant.ETH_ADDRESS);
-        if (_isCurve(_order.makerAddr)) {
+        internalTxData.fromEth = (_params.order.takerAssetAddr == LibConstant.ZERO_ADDRESS || _params.order.takerAssetAddr == LibConstant.ETH_ADDRESS);
+        internalTxData.toEth = (_params.order.makerAssetAddr == LibConstant.ZERO_ADDRESS || _params.order.makerAssetAddr == LibConstant.ETH_ADDRESS);
+        if (_isCurve(_params.order.makerAddr)) {
             // PermanetStorage can recognize `ETH_ADDRESS` but not `ZERO_ADDRESS`.
             // Convert it to `ETH_ADDRESS` as passed in `_order.takerAssetAddr` or `_order.makerAssetAddr` might be `ZERO_ADDRESS`.
-            internalTxData.takerAssetInternalAddr = internalTxData.fromEth ? LibConstant.ETH_ADDRESS : _order.takerAssetAddr;
-            internalTxData.makerAssetInternalAddr = internalTxData.toEth ? LibConstant.ETH_ADDRESS : _order.makerAssetAddr;
+            internalTxData.takerAssetInternalAddr = internalTxData.fromEth ? LibConstant.ETH_ADDRESS : _params.order.takerAssetAddr;
+            internalTxData.makerAssetInternalAddr = internalTxData.toEth ? LibConstant.ETH_ADDRESS : _params.order.makerAssetAddr;
         } else {
-            internalTxData.takerAssetInternalAddr = internalTxData.fromEth ? address(weth) : _order.takerAssetAddr;
-            internalTxData.makerAssetInternalAddr = internalTxData.toEth ? address(weth) : _order.makerAssetAddr;
+            internalTxData.takerAssetInternalAddr = internalTxData.fromEth ? address(weth) : _params.order.takerAssetAddr;
+            internalTxData.makerAssetInternalAddr = internalTxData.toEth ? address(weth) : _params.order.makerAssetAddr;
         }
 
-        txMetaData.transactionHash = _verify(_order, _sig);
+        txMetaData.transactionHash = _verify(_params.order, _params.sig);
 
-        _prepare(_order, internalTxData);
+        _prepare(_params.order, internalTxData, _params.takerAssetPermitSig);
 
         {
             // Set min amount for swap = _order.makerAssetAmount * (10000 / (10000 - feeFactor))
-            uint256 swapMinOutAmount = _order.makerAssetAmount.mul(LibConstant.BPS_MAX).div(LibConstant.BPS_MAX.sub(txMetaData.feeFactor));
-            (txMetaData.source, txMetaData.receivedAmount) = _swapWithPath(_order, internalTxData, swapMinOutAmount);
+            uint256 swapMinOutAmount = _params.order.makerAssetAmount.mul(LibConstant.BPS_MAX).div(LibConstant.BPS_MAX.sub(txMetaData.feeFactor));
+            (txMetaData.source, txMetaData.receivedAmount) = _swapWithPath(_params.order, internalTxData, swapMinOutAmount);
 
             // Settle
             // Calculate fee using actually received from swap
             uint256 actualFee = txMetaData.receivedAmount.mul(txMetaData.feeFactor).div(LibConstant.BPS_MAX);
             txMetaData.settleAmount = txMetaData.receivedAmount.sub(actualFee);
-            require(txMetaData.settleAmount >= _order.makerAssetAmount, "AMMWrapper: insufficient maker output");
-            _settle(_order, internalTxData, txMetaData.settleAmount, actualFee);
+            require(txMetaData.settleAmount >= _params.order.makerAssetAmount, "AMMWrapper: insufficient maker output");
+            _settle(_params.order, internalTxData, txMetaData.settleAmount, actualFee);
         }
 
-        emitSwappedEvent(_order, txMetaData);
+        emitSwappedEvent(_params.order, txMetaData);
         return txMetaData.settleAmount;
     }
 

--- a/contracts/interfaces/IAMMWrapper.sol
+++ b/contracts/interfaces/IAMMWrapper.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0;
+pragma abicoder v2;
 
 import "./IStrategyBase.sol";
+import "../utils/AMMLibEIP712.sol";
+import "../utils/SpenderLibEIP712.sol";
 
 interface IAMMWrapper is IStrategyBase {
     // Operator events
@@ -35,16 +38,9 @@ interface IAMMWrapper is IStrategyBase {
     }
 
     function trade(
-        address _makerAddress,
-        address _fromAssetAddress,
-        address _toAssetAddress,
-        uint256 _takerAssetAmount,
-        uint256 _makerAssetAmount,
+        AMMLibEIP712.Order calldata _order,
         uint256 _feeFactor,
-        address _spender,
-        address payable _receiver,
-        uint256 _nonce,
-        uint256 _deadline,
-        bytes memory _sig
+        bytes calldata _sig,
+        bytes calldata _takerAssetPermitSig
     ) external payable returns (uint256);
 }

--- a/contracts/interfaces/IAMMWrapper.sol
+++ b/contracts/interfaces/IAMMWrapper.sol
@@ -4,7 +4,6 @@ pragma abicoder v2;
 
 import "./IStrategyBase.sol";
 import "../utils/AMMLibEIP712.sol";
-import "../utils/SpenderLibEIP712.sol";
 
 interface IAMMWrapper is IStrategyBase {
     // Operator events
@@ -26,8 +25,7 @@ interface IAMMWrapper is IStrategyBase {
         uint16 feeFactor
     );
 
-    // Group the local variables together to prevent
-    // Compiler error: Stack too deep, try removing local variables.
+    // Group the local variables together to prevent stack too deep error.
     struct TxMetaData {
         string source;
         bytes32 transactionHash;

--- a/contracts/interfaces/IAMMWrapperWithPath.sol
+++ b/contracts/interfaces/IAMMWrapperWithPath.sol
@@ -6,8 +6,7 @@ import "./IAMMWrapper.sol";
 import "../utils/AMMLibEIP712.sol";
 
 interface IAMMWrapperWithPath is IAMMWrapper {
-    // Group the local variables together to prevent
-    // Compiler error: Stack too deep, try removing local variables.
+    // Group the local variables together to prevent stack too deep error.
     struct TradeWithPathParams {
         AMMLibEIP712.Order order;
         uint256 feeFactor;

--- a/contracts/interfaces/IAMMWrapperWithPath.sol
+++ b/contracts/interfaces/IAMMWrapperWithPath.sol
@@ -6,11 +6,16 @@ import "./IAMMWrapper.sol";
 import "../utils/AMMLibEIP712.sol";
 
 interface IAMMWrapperWithPath is IAMMWrapper {
-    function trade(
-        AMMLibEIP712.Order calldata _order,
-        uint256 _feeFactor,
-        bytes calldata _sig,
-        bytes calldata _makerSpecificData,
-        address[] calldata _path
-    ) external payable returns (uint256);
+    // Group the local variables together to prevent
+    // Compiler error: Stack too deep, try removing local variables.
+    struct TradeWithPathParams {
+        AMMLibEIP712.Order order;
+        uint256 feeFactor;
+        bytes sig;
+        bytes takerAssetPermitSig;
+        bytes makerSpecificData;
+        address[] path;
+    }
+
+    function trade(TradeWithPathParams calldata _params) external payable returns (uint256);
 }

--- a/contracts/test/forkMainnet/AMMWrapper/CollectFee.t.sol
+++ b/contracts/test/forkMainnet/AMMWrapper/CollectFee.t.sol
@@ -16,8 +16,17 @@ contract TestAMMWrapperCollectFee is TestAMMWrapper {
         uint256 expectedOutAmount = ammQuoter.getMakerOutAmount(order.makerAddr, order.takerAssetAddr, order.makerAssetAddr, order.takerAssetAmount);
         order.makerAssetAmount = expectedOutAmount;
         bytes memory sig = _signTrade(userPrivateKey, order);
-        bytes memory payload = _genTradePayload(order, feeFactor, sig);
-
+        bytes memory payload; // Bypass stack too deep error
+        {
+            SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = _createSpenderPermitFromOrder(order);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            payload = _genTradePayload(order, feeFactor, sig, takerAssetPermitSig);
+        }
         vm.expectRevert("UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT");
         vm.prank(relayer, relayer);
         userProxy.toAMM(payload);
@@ -33,8 +42,17 @@ contract TestAMMWrapperCollectFee is TestAMMWrapper {
         // therefore it should deduct fee from expectedOutAmount as the makerAssetAmount in order
         order.makerAssetAmount = settleAmount;
         bytes memory sig = _signTrade(userPrivateKey, order);
-        bytes memory payload = _genTradePayload(order, feeFactor, sig);
-
+        bytes memory payload; // Bypass stack too deep error
+        {
+            SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = _createSpenderPermitFromOrder(order);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            payload = _genTradePayload(order, feeFactor, sig, takerAssetPermitSig);
+        }
         BalanceSnapshot.Snapshot memory feeCollectorMakerAsset = BalanceSnapshot.take(feeCollector, order.makerAssetAddr);
 
         vm.prank(relayer, relayer);
@@ -54,8 +72,17 @@ contract TestAMMWrapperCollectFee is TestAMMWrapper {
         // therefore it should deduct fee from expectedOutAmount as the makerAssetAmount in order
         order.makerAssetAmount = settleAmount;
         bytes memory sig = _signTrade(userPrivateKey, order);
-        bytes memory payload = _genTradePayload(order, feeFactor, sig);
-
+        bytes memory payload; // Bypass stack too deep error
+        {
+            SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = _createSpenderPermitFromOrder(order);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            payload = _genTradePayload(order, feeFactor, sig, takerAssetPermitSig);
+        }
         address feeTokenAddress = WETH_ADDRESS; // AMM other than Curve returns WETH instead of ETH
         BalanceSnapshot.Snapshot memory feeCollectorMakerAsset = BalanceSnapshot.take(feeCollector, feeTokenAddress);
 
@@ -79,8 +106,17 @@ contract TestAMMWrapperCollectFee is TestAMMWrapper {
         // therefore it should deduct fee from expectedOutAmount as the makerAssetAmount in order
         order.makerAssetAmount = settleAmount;
         bytes memory sig = _signTrade(userPrivateKey, order);
-        bytes memory payload = _genTradePayload(order, feeFactor, sig);
-
+        bytes memory payload; // Bypass stack too deep error
+        {
+            SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = _createSpenderPermitFromOrder(order);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            payload = _genTradePayload(order, feeFactor, sig, takerAssetPermitSig);
+        }
         address feeTokenAddress = ETH_ADDRESS; // Curve ETH/ANKRETH pool returns ETH instead of WETH
         BalanceSnapshot.Snapshot memory feeCollectorMakerAsset = BalanceSnapshot.take(feeCollector, feeTokenAddress);
 
@@ -104,7 +140,17 @@ contract TestAMMWrapperCollectFee is TestAMMWrapper {
         }
 
         bytes memory sig = _signTrade(userPrivateKey, order);
-        bytes memory payload = _genTradePayload(order, feeFactor, sig);
+        bytes memory payload; // Bypass stack too deep error
+        {
+            SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = _createSpenderPermitFromOrder(order);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            payload = _genTradePayload(order, feeFactor, sig, takerAssetPermitSig);
+        }
         uint256 actualFee = (expectedOutAmount * DEFAULT_FEE_FACTOR) / LibConstant.BPS_MAX;
 
         BalanceSnapshot.Snapshot memory feeCollectorMakerAsset = BalanceSnapshot.take(feeCollector, order.makerAssetAddr);

--- a/contracts/test/forkMainnet/AMMWrapper/Setup.t.sol
+++ b/contracts/test/forkMainnet/AMMWrapper/Setup.t.sol
@@ -12,7 +12,6 @@ import "contracts-test/utils/Permit.sol";
 import { getEIP712Hash } from "contracts-test/utils/Sig.sol";
 
 contract TestAMMWrapper is StrategySharedSetup, Permit {
-    uint256 constant BPS_MAX = 10000;
     bytes32 public constant relayerValidStorageId = 0x2c97779b4deaf24e9d46e02ec2699240a957d92782b51165b93878b09dd66f61; // keccak256("relayerValid")
 
     uint256 userPrivateKey = uint256(1);

--- a/contracts/test/forkMainnet/AMMWrapper/Setup.t.sol
+++ b/contracts/test/forkMainnet/AMMWrapper/Setup.t.sol
@@ -153,7 +153,7 @@ contract TestAMMWrapper is StrategySharedSetup, Permit {
         uint256 feeFactor,
         bytes memory sig,
         bytes memory takerAssetPermitSig
-    ) internal view returns (bytes memory payload) {
+    ) internal pure returns (bytes memory payload) {
         return abi.encodeWithSelector(AMMWrapper.trade.selector, order, feeFactor, sig, takerAssetPermitSig);
     }
 }

--- a/contracts/test/forkMainnet/AMMWrapper/Setup.t.sol
+++ b/contracts/test/forkMainnet/AMMWrapper/Setup.t.sol
@@ -63,17 +63,17 @@ contract TestAMMWrapper is StrategySharedSetup, Permit {
         setEOABalanceAndApprove(user, tokens, uint256(100));
 
         // Default order
-        DEFAULT_ORDER = AMMLibEIP712.Order(
-            UNISWAP_V2_ADDRESS, // makerAddr
-            address(dai), // takerAssetAddr
-            address(usdt), // makerAssetAddr
-            uint256(100 * 1e18), // takerAssetAmount
-            uint256(90 * 1e6), // makerAssetAmount
-            user, // userAddr
-            payable(user), // receiverAddr
-            uint256(1234), // salt
-            DEADLINE // deadline
-        );
+        DEFAULT_ORDER = AMMLibEIP712.Order({
+            makerAddr: UNISWAP_V2_ADDRESS,
+            takerAssetAddr: address(dai),
+            makerAssetAddr: address(usdt),
+            takerAssetAmount: uint256(100 * 1e18),
+            makerAssetAmount: uint256(90 * 1e6),
+            userAddr: user,
+            receiverAddr: payable(user),
+            salt: uint256(1234),
+            deadline: DEADLINE
+        });
 
         // Label addresses for easier debugging
         vm.label(user, "User");
@@ -136,15 +136,15 @@ contract TestAMMWrapper is StrategySharedSetup, Permit {
     }
 
     function _createSpenderPermitFromOrder(AMMLibEIP712.Order memory order) internal view returns (SpenderLibEIP712.SpendWithPermit memory takerAssetPermit) {
-        takerAssetPermit = SpenderLibEIP712.SpendWithPermit(
-            order.takerAssetAddr,
-            address(ammWrapper),
-            order.userAddr,
-            address(ammWrapper),
-            order.takerAssetAmount,
-            AMMLibEIP712._getOrderHash(order),
-            uint64(order.deadline)
-        );
+        takerAssetPermit = SpenderLibEIP712.SpendWithPermit({
+            tokenAddr: order.takerAssetAddr,
+            requester: address(ammWrapper),
+            user: order.userAddr,
+            recipient: address(ammWrapper),
+            amount: order.takerAssetAmount,
+            actionHash: AMMLibEIP712._getOrderHash(order),
+            expiry: uint64(order.deadline)
+        });
         return takerAssetPermit;
     }
 

--- a/contracts/test/forkMainnet/AMMWrapper/Setup.t.sol
+++ b/contracts/test/forkMainnet/AMMWrapper/Setup.t.sol
@@ -135,21 +135,15 @@ contract TestAMMWrapper is StrategySharedSetup, Permit {
         sig = abi.encodePacked(r, s, v, bytes32(0), uint8(2));
     }
 
-    function _createSpenderPermitFromOrder(AMMLibEIP712.Order memory defaultOrder)
-        internal
-        view
-        returns (SpenderLibEIP712.SpendWithPermit memory takerAssetPermit)
-    {
-        // Declare the 'userAddr sends takerAssetAmount amount of takerAssetAddr to AMM contract'
-        // SpendWithPermit struct from defaultOrder parameter
+    function _createSpenderPermitFromOrder(AMMLibEIP712.Order memory order) internal view returns (SpenderLibEIP712.SpendWithPermit memory takerAssetPermit) {
         takerAssetPermit = SpenderLibEIP712.SpendWithPermit(
-            defaultOrder.takerAssetAddr,
+            order.takerAssetAddr,
             address(ammWrapper),
-            defaultOrder.userAddr,
+            order.userAddr,
             address(ammWrapper),
-            defaultOrder.takerAssetAmount,
-            AMMLibEIP712._getOrderHash(defaultOrder),
-            uint64(defaultOrder.deadline)
+            order.takerAssetAmount,
+            AMMLibEIP712._getOrderHash(order),
+            uint64(order.deadline)
         );
         return takerAssetPermit;
     }

--- a/contracts/test/forkMainnet/AMMWrapper/TradeUniswapV2.t.sol
+++ b/contracts/test/forkMainnet/AMMWrapper/TradeUniswapV2.t.sol
@@ -10,8 +10,17 @@ contract TestAMMWrapperTradeUniswapV2 is TestAMMWrapper {
     function testCannotTradeWithInvalidSignature() public {
         AMMLibEIP712.Order memory order = DEFAULT_ORDER;
         bytes memory sig = _signTrade(otherPrivateKey, order);
-        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig);
-
+        bytes memory payload; // Bypass stack too deep error
+        {
+            SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = _createSpenderPermitFromOrder(order);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, takerAssetPermitSig);
+        }
         vm.expectRevert("AMMWrapper: invalid user signature");
         userProxy.toAMM(payload);
     }
@@ -19,8 +28,17 @@ contract TestAMMWrapperTradeUniswapV2 is TestAMMWrapper {
     function testCannotTradeWhenPayloadSeenBefore() public {
         AMMLibEIP712.Order memory order = DEFAULT_ORDER;
         bytes memory sig = _signTrade(userPrivateKey, order);
-        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig);
-
+        bytes memory payload; // Bypass stack too deep error
+        {
+            SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = _createSpenderPermitFromOrder(order);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, takerAssetPermitSig);
+        }
         userProxy.toAMM(payload);
 
         vm.expectRevert("PermanentStorage: transaction seen before");
@@ -32,8 +50,17 @@ contract TestAMMWrapperTradeUniswapV2 is TestAMMWrapper {
         order.takerAssetAddr = ETH_ADDRESS;
         order.takerAssetAmount = 0.1 ether;
         bytes memory sig = _signTradeWithOldEIP712Method(userPrivateKey, order);
-        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig);
-
+        bytes memory payload; // Bypass stack too deep error
+        {
+            SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = _createSpenderPermitFromOrder(order);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, takerAssetPermitSig);
+        }
         uint256 expectedOutAmount = ammQuoter.getMakerOutAmount(order.makerAddr, order.takerAssetAddr, order.makerAssetAddr, order.takerAssetAmount);
         uint256 actualFee = (expectedOutAmount * DEFAULT_FEE_FACTOR) / LibConstant.BPS_MAX;
         uint256 settleAmount = expectedOutAmount - actualFee;
@@ -55,8 +82,17 @@ contract TestAMMWrapperTradeUniswapV2 is TestAMMWrapper {
         order.takerAssetAddr = ETH_ADDRESS;
         order.takerAssetAmount = 0.1 ether;
         bytes memory sig = _signTrade(userPrivateKey, order);
-        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig);
-
+        bytes memory payload; // Bypass stack too deep error
+        {
+            SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = _createSpenderPermitFromOrder(order);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, takerAssetPermitSig);
+        }
         uint256 expectedOutAmount = ammQuoter.getMakerOutAmount(order.makerAddr, order.takerAssetAddr, order.makerAssetAddr, order.takerAssetAmount);
         uint256 actualFee = (expectedOutAmount * DEFAULT_FEE_FACTOR) / LibConstant.BPS_MAX;
         uint256 settleAmount = expectedOutAmount - actualFee;
@@ -76,8 +112,17 @@ contract TestAMMWrapperTradeUniswapV2 is TestAMMWrapper {
     function testEmitSwappedEvent() public {
         AMMLibEIP712.Order memory order = DEFAULT_ORDER;
         bytes memory sig = _signTrade(userPrivateKey, order);
-        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig);
-
+        bytes memory payload; // Bypass stack too deep error
+        {
+            SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = _createSpenderPermitFromOrder(order);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, takerAssetPermitSig);
+        }
         uint256 expectedOutAmount = ammQuoter.getMakerOutAmount(order.makerAddr, order.takerAssetAddr, order.makerAssetAddr, order.takerAssetAmount);
         uint256 actualFee = (expectedOutAmount * DEFAULT_FEE_FACTOR) / LibConstant.BPS_MAX;
         uint256 settleAmount = expectedOutAmount - actualFee;

--- a/contracts/test/forkMainnet/AMMWrapperWithPath/Setup.t.sol
+++ b/contracts/test/forkMainnet/AMMWrapperWithPath/Setup.t.sol
@@ -156,51 +156,17 @@ contract TestAMMWrapperWithPath is StrategySharedSetup, Permit {
         sig = abi.encodePacked(r, s, v, bytes32(0), uint8(2));
     }
 
-    function _createSpenderPermitFromOrder(AMMLibEIP712.Order memory defaultOrder)
-        internal
-        view
-        returns (SpenderLibEIP712.SpendWithPermit memory takerAssetPermit)
-    {
-        // Declare the 'userAddr sends takerAssetAmount amount of takerAssetAddr to AMM contract'
-        // SpendWithPermit struct from defaultOrder parameter
+    function _createSpenderPermitFromOrder(AMMLibEIP712.Order memory order) internal view returns (SpenderLibEIP712.SpendWithPermit memory takerAssetPermit) {
         takerAssetPermit = SpenderLibEIP712.SpendWithPermit(
-            defaultOrder.takerAssetAddr,
+            order.takerAssetAddr,
             address(ammWrapperWithPath),
-            defaultOrder.userAddr,
+            order.userAddr,
             address(ammWrapperWithPath),
-            defaultOrder.takerAssetAmount,
-            AMMLibEIP712._getOrderHash(defaultOrder),
-            uint64(defaultOrder.deadline)
+            order.takerAssetAmount,
+            AMMLibEIP712._getOrderHash(order),
+            uint64(order.deadline)
         );
         return takerAssetPermit;
-    }
-
-    function _signSpendWithPermit(
-        uint256 privateKey,
-        SpenderLibEIP712.SpendWithPermit memory spendWithPermit,
-        SignatureValidator.SignatureType sigType
-    ) internal returns (bytes memory sig) {
-        uint256 SPEND_WITH_PERMIT_TYPEHASH = 0x52718c957261b99fd72e63478d85d1267cdc812e8249f5a2623566c1818e1ed0;
-        bytes32 structHash = keccak256(
-            abi.encode(
-                SPEND_WITH_PERMIT_TYPEHASH,
-                spendWithPermit.tokenAddr,
-                spendWithPermit.requester,
-                spendWithPermit.user,
-                spendWithPermit.recipient,
-                spendWithPermit.amount,
-                spendWithPermit.actionHash,
-                spendWithPermit.expiry
-            )
-        );
-        bytes32 spendWithPermitHash = getEIP712Hash(spender.EIP712_DOMAIN_SEPARATOR(), structHash);
-        if (sigType == SignatureValidator.SignatureType.Wallet) {
-            (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, ECDSA.toEthSignedMessageHash(spendWithPermitHash));
-            sig = abi.encodePacked(r, s, v, uint8(sigType)); // new signature format
-        } else {
-            (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, spendWithPermitHash);
-            sig = abi.encodePacked(r, s, v, uint8(sigType)); // new signature format
-        }
     }
 
     function _genTradePayload(

--- a/contracts/test/forkMainnet/AMMWrapperWithPath/Setup.t.sol
+++ b/contracts/test/forkMainnet/AMMWrapperWithPath/Setup.t.sol
@@ -72,17 +72,17 @@ contract TestAMMWrapperWithPath is StrategySharedSetup, Permit {
         setEOABalanceAndApprove(user, tokens, uint256(100));
 
         // Default order
-        DEFAULT_ORDER = AMMLibEIP712.Order(
-            UNISWAP_V3_ADDRESS, // makerAddr
-            address(usdc), // takerAssetAddr
-            address(dai), // makerAssetAddr
-            uint256(100 * 1e6), // takerAssetAmount
-            uint256(90 * 1e18), // makerAssetAmount
-            user, // userAddr
-            payable(user), // receiverAddr
-            uint256(1234), // salt
-            DEADLINE // deadline
-        );
+        DEFAULT_ORDER = AMMLibEIP712.Order({
+            makerAddr: UNISWAP_V3_ADDRESS,
+            takerAssetAddr: address(usdc),
+            makerAssetAddr: address(dai),
+            takerAssetAmount: uint256(100 * 1e6),
+            makerAssetAmount: uint256(90 * 1e18),
+            userAddr: user,
+            receiverAddr: payable(user),
+            salt: uint256(1234),
+            deadline: DEADLINE
+        });
         DEFAULT_MULTI_HOP_PATH = new address[](3);
         DEFAULT_MULTI_HOP_PATH[0] = DEFAULT_ORDER.takerAssetAddr;
         DEFAULT_MULTI_HOP_PATH[1] = address(weth);
@@ -157,15 +157,15 @@ contract TestAMMWrapperWithPath is StrategySharedSetup, Permit {
     }
 
     function _createSpenderPermitFromOrder(AMMLibEIP712.Order memory order) internal view returns (SpenderLibEIP712.SpendWithPermit memory takerAssetPermit) {
-        takerAssetPermit = SpenderLibEIP712.SpendWithPermit(
-            order.takerAssetAddr,
-            address(ammWrapperWithPath),
-            order.userAddr,
-            address(ammWrapperWithPath),
-            order.takerAssetAmount,
-            AMMLibEIP712._getOrderHash(order),
-            uint64(order.deadline)
-        );
+        takerAssetPermit = SpenderLibEIP712.SpendWithPermit({
+            tokenAddr: order.takerAssetAddr,
+            requester: address(ammWrapperWithPath),
+            user: order.userAddr,
+            recipient: address(ammWrapperWithPath),
+            amount: order.takerAssetAmount,
+            actionHash: AMMLibEIP712._getOrderHash(order),
+            expiry: uint64(order.deadline)
+        });
         return takerAssetPermit;
     }
 

--- a/contracts/test/forkMainnet/AMMWrapperWithPath/TradeCurveV2.t.sol
+++ b/contracts/test/forkMainnet/AMMWrapperWithPath/TradeCurveV2.t.sol
@@ -17,8 +17,17 @@ contract TestAMMWrapperWithPathTradeCurveV2 is TestAMMWrapperWithPath {
         order.makerAssetAddr = address(wbtc);
         order.makerAssetAmount = 0.001 * 1e8;
         bytes memory sig = _signTrade(userPrivateKey, order);
-        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, _encodeCurveData(2), new address[](0));
-
+        bytes memory payload; // Bypass stack too deep error
+        {
+            SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = _createSpenderPermitFromOrder(order);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, takerAssetPermitSig, _encodeCurveData(2), new address[](0));
+        }
         uint256 expectedOutAmount = ammQuoter.getMakerOutAmountWithPath(
             order.makerAddr,
             order.takerAssetAddr,
@@ -47,8 +56,18 @@ contract TestAMMWrapperWithPathTradeCurveV2 is TestAMMWrapperWithPath {
         order.makerAddr = CURVE_USDT_POOL_ADDRESS;
         bytes memory sig = _signTrade(userPrivateKey, order);
         // Curve USDT pool is version 1 but we input version 2
-        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, _encodeCurveData(2), new address[](0));
-
+        bytes memory payload; // Bypass stack too deep error
+        bytes memory takerAssetPermitSig;
+        {
+            SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = _createSpenderPermitFromOrder(order);
+            takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, takerAssetPermitSig, _encodeCurveData(2), new address[](0));
+        }
         vm.expectRevert("AMMWrapper: Curve v2 no underlying");
         userProxy.toAMM(payload);
 
@@ -58,7 +77,7 @@ contract TestAMMWrapperWithPathTradeCurveV2 is TestAMMWrapperWithPath {
         order.takerAssetAddr = USDC_ADDRESS;
         order.makerAddr = CURVE_USDT_POOL_ADDRESS;
         sig = _signTrade(userPrivateKey, order);
-        payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, _encodeCurveData(2), new address[](0));
+        payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, takerAssetPermitSig, _encodeCurveData(2), new address[](0));
 
         vm.expectRevert("AMMWrapper: Curve v2 no underlying");
         userProxy.toAMM(payload);
@@ -70,8 +89,17 @@ contract TestAMMWrapperWithPathTradeCurveV2 is TestAMMWrapperWithPath {
         // give an unpsorted token to swap
         order.takerAssetAddr = LON_ADDRESS;
         bytes memory sig = _signTrade(userPrivateKey, order);
-        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, _encodeCurveData(2), new address[](0));
-
+        bytes memory payload; // Bypass stack too deep error
+        {
+            SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = _createSpenderPermitFromOrder(order);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, takerAssetPermitSig, _encodeCurveData(2), new address[](0));
+        }
         vm.expectRevert("PermanentStorage: invalid pair");
         userProxy.toAMM(payload);
     }
@@ -83,7 +111,17 @@ contract TestAMMWrapperWithPathTradeCurveV2 is TestAMMWrapperWithPath {
         order.makerAssetAddr = address(wbtc);
         bytes memory sig = _signTrade(userPrivateKey, order);
         // curve doesn't has v3
-        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, _encodeCurveData(3), new address[](0));
+        bytes memory payload; // Bypass stack too deep error
+        {
+            SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = _createSpenderPermitFromOrder(order);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, takerAssetPermitSig, _encodeCurveData(3), new address[](0));
+        }
         vm.expectRevert("AMMWrapper: Invalid Curve version");
         userProxy.toAMM(payload);
     }
@@ -97,8 +135,17 @@ contract TestAMMWrapperWithPathTradeCurveV2 is TestAMMWrapperWithPath {
         order.makerAssetAmount = 0;
 
         bytes memory sig = _signTrade(userPrivateKey, order);
-        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, _encodeCurveData(2), new address[](0));
-
+        bytes memory payload; // Bypass stack too deep error
+        {
+            SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = _createSpenderPermitFromOrder(order);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, takerAssetPermitSig, _encodeCurveData(2), new address[](0));
+        }
         vm.expectRevert();
         userProxy.toAMM(payload);
     }
@@ -113,8 +160,19 @@ contract TestAMMWrapperWithPathTradeCurveV2 is TestAMMWrapperWithPath {
         address[] memory path = new address[](2);
 
         bytes memory sig = _signTrade(userPrivateKey, order);
-        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, _encodeCurveData(2), path);
-
+        bytes memory payload; // Bypass stack too deep error
+        {
+            SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = _createSpenderPermitFromOrder(order);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, takerAssetPermitSig, _encodeCurveData(2), path);
+        }
+        // More stack than the one curly bracket can handle,
+        // use the second curly bracket to bypass stack too deep error
         {
             uint256 expectedOutAmount = ammQuoter.getMakerOutAmountWithPath(
                 order.makerAddr,
@@ -154,8 +212,12 @@ contract TestAMMWrapperWithPathTradeCurveV2 is TestAMMWrapperWithPath {
         order.makerAssetAddr = address(wbtc);
         order.makerAssetAmount = 1000 * 1e8; // unlikely to fill this amount
         bytes memory sig = _signTrade(userPrivateKey, order);
-        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, _encodeCurveData(2), new address[](0));
-
+        bytes memory payload; // Bypass stack too deep error
+        {
+            SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = _createSpenderPermitFromOrder(order);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender.EIP712_DOMAIN_SEPARATOR(),SignatureValidator.SignatureType.EIP712);
+            payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, takerAssetPermitSig, _encodeCurveData(2), new address[](0));
+        }
         vm.expectRevert("Slippage");
         userProxy.toAMM(payload);
     }

--- a/contracts/test/forkMainnet/AMMWrapperWithPath/TradeCurveV2.t.sol
+++ b/contracts/test/forkMainnet/AMMWrapperWithPath/TradeCurveV2.t.sol
@@ -215,7 +215,12 @@ contract TestAMMWrapperWithPathTradeCurveV2 is TestAMMWrapperWithPath {
         bytes memory payload; // Bypass stack too deep error
         {
             SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = _createSpenderPermitFromOrder(order);
-            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender.EIP712_DOMAIN_SEPARATOR(),SignatureValidator.SignatureType.EIP712);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
             payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, takerAssetPermitSig, _encodeCurveData(2), new address[](0));
         }
         vm.expectRevert("Slippage");

--- a/contracts/test/forkMainnet/AMMWrapperWithPath/TradeSushiswap.t.sol
+++ b/contracts/test/forkMainnet/AMMWrapperWithPath/TradeSushiswap.t.sol
@@ -91,7 +91,12 @@ contract TestAMMWrapperWithPathTradeSushiswap is TestAMMWrapperWithPath {
         bytes memory payload; // Bypass stack too deep error
         {
             SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = _createSpenderPermitFromOrder(order);
-            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender.EIP712_DOMAIN_SEPARATOR(),SignatureValidator.SignatureType.EIP712);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
             payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, takerAssetPermitSig, makerSpecificData, path);
         }
         uint256 expectedOutAmount = ammQuoter.getMakerOutAmountWithPath(

--- a/contracts/test/forkMainnet/AMMWrapperWithPath/TradeSushiswap.t.sol
+++ b/contracts/test/forkMainnet/AMMWrapperWithPath/TradeSushiswap.t.sol
@@ -16,8 +16,17 @@ contract TestAMMWrapperWithPathTradeSushiswap is TestAMMWrapperWithPath {
         bytes memory sig = _signTrade(userPrivateKey, order);
         address[] memory path = new address[](0);
         bytes memory makerSpecificData = bytes("");
-        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, makerSpecificData, path);
-
+        bytes memory payload; // Bypass stack too deep error
+        {
+            SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = _createSpenderPermitFromOrder(order);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, takerAssetPermitSig, makerSpecificData, path);
+        }
         uint256 expectedOutAmount = ammQuoter.getMakerOutAmount(order.makerAddr, order.takerAssetAddr, order.makerAssetAddr, order.takerAssetAmount);
         uint256 actualFee = (expectedOutAmount * DEFAULT_FEE_FACTOR) / LibConstant.BPS_MAX;
         uint256 settleAmount = expectedOutAmount - actualFee;
@@ -42,8 +51,17 @@ contract TestAMMWrapperWithPathTradeSushiswap is TestAMMWrapperWithPath {
         bytes memory sig = _signTradeWithOldEIP712Method(userPrivateKey, order);
         address[] memory path = new address[](0);
         bytes memory makerSpecificData = bytes("");
-        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, makerSpecificData, path);
-
+        bytes memory payload; // Bypass stack too deep error
+        {
+            SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = _createSpenderPermitFromOrder(order);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(
+                userPrivateKey,
+                takerAssetPermit,
+                spender.EIP712_DOMAIN_SEPARATOR(),
+                SignatureValidator.SignatureType.EIP712
+            );
+            payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, takerAssetPermitSig, makerSpecificData, path);
+        }
         uint256 expectedOutAmount = ammQuoter.getMakerOutAmount(order.makerAddr, order.takerAssetAddr, order.makerAssetAddr, order.takerAssetAmount);
         uint256 actualFee = (expectedOutAmount * DEFAULT_FEE_FACTOR) / LibConstant.BPS_MAX;
         uint256 settleAmount = expectedOutAmount - actualFee;
@@ -70,8 +88,12 @@ contract TestAMMWrapperWithPathTradeSushiswap is TestAMMWrapperWithPath {
         path[1] = address(dai);
         path[2] = address(weth);
         bytes memory makerSpecificData = bytes("");
-        bytes memory payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, makerSpecificData, path);
-
+        bytes memory payload; // Bypass stack too deep error
+        {
+            SpenderLibEIP712.SpendWithPermit memory takerAssetPermit = _createSpenderPermitFromOrder(order);
+            bytes memory takerAssetPermitSig = signSpendWithPermit(userPrivateKey, takerAssetPermit, spender.EIP712_DOMAIN_SEPARATOR(),SignatureValidator.SignatureType.EIP712);
+            payload = _genTradePayload(order, DEFAULT_FEE_FACTOR, sig, takerAssetPermitSig, makerSpecificData, path);
+        }
         uint256 expectedOutAmount = ammQuoter.getMakerOutAmountWithPath(
             order.makerAddr,
             order.takerAssetAddr,


### PR DESCRIPTION
1. Remove spendFromUser and spendFromUserTo func.
2. Reduce parameters of trade() function to avoid stack too deep error.
3. Add the takerAssetPermitSig parameter of the trade() function to authenticate the spendFromUserToWithPermit function.
4. Because AMMWrapper and AMMWrapperWithPath use the same _prepare() function, they need to be modified together.
5. Modify Foundry tests for AMMWrapper and AMMWrapperWithPath to use trade() function with takerAssetPermitSig parameter.
6. In Foundry tests, use curly braces to avoid stack too deep error.
7. Verify command:
```shell
tokenlon-contracts % MAINNET_NODE_RPC_URL="https://eth-mainnet.g.alchemy.com/v2/<YOUR API KEY>"

tokenlon-contracts % DEPLOYED=false forge test -vvv --fork-url ${MAINNET_NODE_RPC_URL} --fork-block-number '15451000' --match-path 'contracts/test/forkMainnet/AMMWrapper/*.t.sol'
tokenlon-contracts % DEPLOYED=false forge test -vvv --fork-url ${MAINNET_NODE_RPC_URL} --fork-block-number '15451000' --match-path 'contracts/test/forkMainnet/AMMWrapperWithPath/*.t.sol'
```

<details>
  <summary>Output: (Please click here to expand)</summary>
    <pre><code>

tokenlon-contracts % DEPLOYED=false forge test -vvv --fork-url ${MAINNET_NODE_RPC_URL} --fork-block-number '15451000' --match-path 'contracts/test/forkMainnet/AMMWrapper/*.t.sol' 


warning: Unknown section [default] found in foundry.toml. This notation for profiles has been deprecated and may result in the profile not being registered in future versions. Please use [profile.default] instead or run `forge config --fix`.
[⠔] Compiling...
No files changed, compilation skipped

Running 2 tests for contracts/test/forkMainnet/AMMWrapper/SetFeeCollector.t.sol:TestAMMWrapperSetFeeCollector
[PASS] testCannotSetFeeCollectorByNotOwner() (gas: 13350)
[PASS] testSetFeeCollector() (gas: 23970)
Test result: ok. 2 passed; 0 failed; finished in 51.43ms

Running 3 tests for contracts/test/forkMainnet/AMMWrapper/Allowance.t.sol:TestAMMWrapperAllowance
[PASS] testAllowance() (gas: 47300)
[PASS] testCannotCloseByNotOwner() (gas: 15986)
[PASS] testCannotSetByNotOwner() (gas: 16000)
Test result: ok. 3 passed; 0 failed; finished in 52.23ms

Running 3 tests for contracts/test/forkMainnet/AMMWrapper/UpgradeSpender.t.sol:TestAMMWrapperUpgradeSpender
[PASS] testCannotUpgradeByNotOwner() (gas: 13415)
[PASS] testCannotUpgradeToZeroAddress() (gas: 13385)
[PASS] testUpgradeSpender() (gas: 22226)
Test result: ok. 3 passed; 0 failed; finished in 51.69ms

Running 2 tests for contracts/test/forkMainnet/AMMWrapper/DepositETH.t.sol:TestAMMWrapperDepositETH
[PASS] testCannotDepositByNotOwner() (gas: 13110)
[PASS] testDepositETH() (gas: 49098)
Test result: ok. 2 passed; 0 failed; finished in 54.66ms

Running 2 tests for contracts/test/forkMainnet/AMMWrapper/SetupTest.t.sol:TestAMMWrapperSetup
[PASS] testAMMWrapperSetup() (gas: 66259)
[PASS] testTokensAllowanceAmountWhenSetup() (gas: 82112)
Test result: ok. 2 passed; 0 failed; finished in 59.12ms

Running 1 test for contracts/test/forkMainnet/AMMWrapper/TradeCurveV1.t.sol:TestAMMWrapperTradeCurveV1
[PASS] testTradeCurveV1() (gas: 534287)
Test result: ok. 1 passed; 0 failed; finished in 115.31ms

Running 5 tests for contracts/test/forkMainnet/AMMWrapper/TradeUniswapV2.t.sol:TestAMMWrapperTradeUniswapV2
[PASS] testCannotTradeWhenPayloadSeenBefore() (gas: 345016)
[PASS] testCannotTradeWithInvalidSignature() (gas: 93839)
[PASS] testEmitSwappedEvent() (gas: 342464)
[PASS] testTradeUniswapV2() (gas: 306402)
[PASS] testTradeWithOldEIP712Signature() (gas: 306060)
Test result: ok. 5 passed; 0 failed; finished in 125.00ms

Running 1 test for contracts/test/forkMainnet/AMMWrapper/TradeSushiswap.t.sol:TestAMMWrapperTradeSushiswap
[PASS] testTradeSushiswap() (gas: 330646)
Test result: ok. 1 passed; 0 failed; finished in 43.97ms

Running 5 tests for contracts/test/forkMainnet/AMMWrapper/CollectFee.t.sol:TestAMMWrapperCollectFee
[PASS] testAMMOutNotEnoughForOrderPlusFee() (gas: 259538)
[PASS] testCollectFeeForSwap() (gas: 341498)
[PASS] testCollectFeeWithETH() (gas: 376587)
[PASS] testCollectFeeWithWETH() (gas: 330184)
[PASS] testFeeFactorOverwrittenWithDefault() (gas: 345485)
Test result: ok. 5 passed; 0 failed; finished in 130.87ms


tokenlon-contracts % DEPLOYED=false forge test -vvv --fork-url ${MAINNET_NODE_RPC_URL} --fork-block-number '15451000' --match-path 'contracts/test/forkMainnet/AMMWrapperWithPath/*.t.sol'


warning: Unknown section [default] found in foundry.toml. This notation for profiles has been deprecated and may result in the profile not being registered in future versions. Please use [profile.default] instead or run `forge config --fix`.
[⠔] Compiling...
No files changed, compilation skipped

Running 2 tests for contracts/test/forkMainnet/AMMWrapperWithPath/SetupTest.t.sol:TestAMMWrapperWithPathSetup
[PASS] testAMMWrapperWithPathSetup() (gas: 65634)
[PASS] testTokensAllowanceAmountWhenSetup() (gas: 83104)
Test result: ok. 2 passed; 0 failed; finished in 41.92ms

Running 1 test for contracts/test/forkMainnet/AMMWrapperWithPath/TradeCurveV1.t.sol:TestAMMWrapperWithPathTradeCurveV1
[PASS] testTradeCurveV1() (gas: 643382)
Test result: ok. 1 passed; 0 failed; finished in 137.63ms

Running 3 tests for contracts/test/forkMainnet/AMMWrapperWithPath/TradeSushiswap.t.sol:TestAMMWrapperWithPathTradeSushiswap
[PASS] testTradeWithMultiHop() (gas: 439377)
[PASS] testTradeWithSingleHop() (gas: 364766)
[PASS] testTradeWithSingleHopWithOldEIP712Signature() (gas: 364742)
Test result: ok. 3 passed; 0 failed; finished in 142.57ms

Running 10 tests for contracts/test/forkMainnet/AMMWrapperWithPath/TradeBalancerV2.t.sol:TestAMMWrapperWithPathTradeBalancerV2
[PASS] testCannotTradeBalancerV2InvalidAmountInSwapSteps() (gas: 502505)
[PASS] testCannotTradeBalancerV2MismatchAsset() (gas: 490348)
[PASS] testCannotTradeBalancerV2NoPath() (gas: 263017)
[PASS] testCannotTradeBalancerV2NoSwapSteps() (gas: 262346)
[PASS] testCannotTradeBalancerV2UnsupportedMakerAsset() (gas: 286447)
[PASS] testCannotTradeBalancerV2UnsupportedTakerAsset() (gas: 267007)
[PASS] testTradeBalancerV2MultiHop() (gas: 534143)
[PASS] testTradeBalancerV2SingleHop() (gas: 472996)
[PASS] testTradeBalanerV2EmitSwappedeventMultiHop() (gas: 529236)
[PASS] testTradeBalanerV2EmitSwappedeventSingleHop() (gas: 468233)
Test result: ok. 10 passed; 0 failed; finished in 143.15ms

Running 13 tests for contracts/test/forkMainnet/AMMWrapperWithPath/TradeUniswapV3.t.sol:TestAMMWrapperWithPathTradeUniswapV3
[PASS] testCannotTradeMultiPoolWithInvalidFeeFormat() (gas: 267717)
[PASS] testCannotTradeMultiPoolWithInvalidPathFormat() (gas: 496477)
[PASS] testCannotTradeMultiPoolWithMismatchAsset() (gas: 512239)
[PASS] testCannotTradeSinglePoolWithInvalidPoolFee() (gas: 503978)
[PASS] testCannotTradeSinglePoolWithInvalidSwapType() (gas: 8797746687696168073)
[PASS] testCannotTradeWhenPayloadSeenBefore() (gas: 372408)
[PASS] testCannotTradeWithInvalidSignature() (gas: 93536)
[PASS] testCannotTradeWithMoreThanSettleAmount() (gas: 630511)
[PASS] testEmitSwappedEvent() (gas: 573557)
[PASS] testTradeWithExactSettleAmount() (gas: 608980)
[PASS] testTradeWithMultiHop() (gas: 609031)
[PASS] testTradeWithSingleExactInput() (gas: 450067)
[PASS] testTradeWithSingleHop() (gas: 462590)
Test result: ok. 13 passed; 0 failed; finished in 144.40ms

Running 7 tests for contracts/test/forkMainnet/AMMWrapperWithPath/TradeCurveV2.t.sol:TestAMMWrapperWithPathTradeCurveV2
[PASS] testCannotTradeCurveV2InsufficientOutput() (gas: 381350)
[PASS] testCannotTradeCurveV2WithMismatchedAsset() (gas: 252128)
[PASS] testCannotTradeCurveV2WithUnknownVersion() (gas: 268833)
[PASS] testCannotTradeCurveV2WithV1Method() (gas: 513895)
[PASS] testCannotTradeCurveV2WithZeroAmount() (gas: 247172)
[PASS] testTradeCurveV2EmitSwappedevent() (gas: 608794)
[PASS] testTradeCurveVersion2() (gas: 613469)
Test result: ok. 7 passed; 0 failed; finished in 152.41ms
    </code></pre>
</details>

Thank you very much!