### PR TITLE
Adjust RFQ weth handling

### DIFF
--- a/contracts/RFQ.sol
+++ b/contracts/RFQ.sol
@@ -142,7 +142,7 @@ contract RFQ is IRFQ, StrategyBase, ReentrancyGuard, SignatureValidator, BaseLib
     // settle
     function _settle(RFQLibEIP712.Order memory _order, GroupedVars memory _vars) internal returns (uint256) {
         // Transfer taker asset to maker
-        if (address(weth) == _order.takerAssetAddr) {
+        if (_order.takerAssetAddr == LibConstant.ETH_ADDRESS) {
             // Deposit to WETH if taker asset is ETH
             require(msg.value == _order.takerAssetAmount, "RFQ: insufficient ETH");
             weth.deposit{ value: msg.value }();
@@ -167,7 +167,8 @@ contract RFQ is IRFQ, StrategyBase, ReentrancyGuard, SignatureValidator, BaseLib
         } else {
             spender.spendFromUserTo(_order.makerAddr, _order.makerAssetAddr, _order.receiverAddr, settleAmount);
         }
-        // Collect fee
+
+        // Collect fee (without unwrap if WETH)
         if (fee > 0) {
             spender.spendFromUserTo(_order.makerAddr, _order.makerAssetAddr, feeCollector, fee);
         }

--- a/contracts/RFQ.sol
+++ b/contracts/RFQ.sol
@@ -144,7 +144,7 @@ contract RFQ is IRFQ, StrategyBase, ReentrancyGuard, SignatureValidator, BaseLib
         // Transfer taker asset to maker
         if (_order.takerAssetAddr == LibConstant.ETH_ADDRESS) {
             // Deposit to WETH if taker asset is ETH
-            require(msg.value == _order.takerAssetAmount, "RFQ: insufficient ETH");
+            require(msg.value == _order.takerAssetAmount, "RFQ: incorrect ETH amount");
             weth.deposit{ value: msg.value }();
             weth.transfer(_order.makerAddr, _order.takerAssetAmount);
         } else {

--- a/contracts/utils/RFQLibEIP712.sol
+++ b/contracts/utils/RFQLibEIP712.sol
@@ -56,12 +56,12 @@ library RFQLibEIP712 {
         );
     }
 
-    bytes32 public constant FILL_WITH_PERMIT_TYPEHASH = 0x4ea663383968865a4516f51bec2c29addd1e7cecce5583296a44cc8d568cad09;
+    bytes32 public constant FILL_TYPEHASH = 0x9b822fe3212f0c2a34b120a750281383593d621b7cee5888ef0bdc840bf6ff2c;
 
     /*
         keccak256(
             abi.encodePacked(
-                "fillWithPermit(",
+                "fill(",
                 "address makerAddr,",
                 "address takerAssetAddr,",
                 "address makerAssetAddr,",
@@ -80,7 +80,7 @@ library RFQLibEIP712 {
     function _getTransactionHash(Order memory _order) internal pure returns (bytes32 transactionHash) {
         transactionHash = keccak256(
             abi.encode(
-                FILL_WITH_PERMIT_TYPEHASH,
+                FILL_TYPEHASH,
                 _order.makerAddr,
                 _order.takerAssetAddr,
                 _order.makerAssetAddr,


### PR DESCRIPTION
Allow WETH as taker asset. Wrap raw ETH only if taker specified and `msg.value` match the taker amount.