### PR TITLE
feat: remove spendFromUser() func in Spender.sol

### DIFF
--- a/contracts/Spender.sol
+++ b/contracts/Spender.sol
@@ -172,18 +172,6 @@ contract Spender is ISpender, Ownable, BaseLibEIP712, SignatureValidator {
     /// @dev Spend tokens on user's behalf. Only an authority can call this.
     /// @param _user The user to spend token from.
     /// @param _tokenAddr The address of the token.
-    /// @param _amount Amount to spend.
-    function spendFromUser(
-        address _user,
-        address _tokenAddr,
-        uint256 _amount
-    ) external override onlyAuthorized {
-        _transferTokenFromUserTo(_user, _tokenAddr, msg.sender, _amount);
-    }
-
-    /// @dev Spend tokens on user's behalf. Only an authority can call this.
-    /// @param _user The user to spend token from.
-    /// @param _tokenAddr The address of the token.
     /// @param _recipient The receiver of the token.
     /// @param _amount Amount to spend.
     function spendFromUserTo(

--- a/contracts/interfaces/ISpender.sol
+++ b/contracts/interfaces/ISpender.sol
@@ -15,12 +15,6 @@ interface ISpender {
     event BlackListToken(address token, bool isBlacklisted);
     event AuthorizeSpender(address spender, bool isAuthorized);
 
-    function spendFromUser(
-        address _user,
-        address _tokenAddr,
-        uint256 _amount
-    ) external;
-
     function spendFromUserTo(
         address _user,
         address _tokenAddr,

--- a/contracts/test/Spender.t.sol
+++ b/contracts/test/Spender.t.sol
@@ -211,60 +211,6 @@ contract SpenderTest is BalanceUtil, Permit {
     }
 
     /*********************************
-     *     Test: spendFromUser       *
-     *********************************/
-
-    function testCannotSpendFromUserByNotAuthorized() public {
-        vm.expectRevert("Spender: not authorized");
-        vm.prank(unauthorized);
-        spender.spendFromUser(user, address(lon), 100);
-    }
-
-    function testCannotSpendFromUserWithBlakclistedToken() public {
-        address[] memory blacklistAddress = new address[](1);
-        blacklistAddress[0] = address(lon);
-        bool[] memory blacklistBool = new bool[](1);
-        blacklistBool[0] = true;
-        spender.blacklist(blacklistAddress, blacklistBool);
-
-        vm.expectRevert("Spender: token is blacklisted");
-        spender.spendFromUser(user, address(lon), 100);
-    }
-
-    function testCannotSpendFromUserInsufficientBalance_NoReturnValueToken() public {
-        uint256 userBalance = noReturnERC20.balanceOf(user);
-        vm.expectRevert("Spender: ERC20 transferFrom failed");
-        spender.spendFromUser(user, address(noReturnERC20), userBalance + 1);
-    }
-
-    function testCannotSpendFromUserInsufficientBalance_ReturnFalseToken() public {
-        uint256 userBalance = noRevertERC20.balanceOf(user);
-        vm.expectRevert("Spender: ERC20 transferFrom failed");
-        spender.spendFromUser(user, address(noRevertERC20), userBalance + 1);
-    }
-
-    function testCannotSpendFromUserWithDeflationaryToken() public {
-        vm.expectRevert("Spender: ERC20 transferFrom amount mismatch");
-        spender.spendFromUser(user, address(deflationaryERC20), 100);
-    }
-
-    function testSpendFromUser() public {
-        assertEq(lon.balanceOf(address(this)), 0);
-
-        spender.spendFromUser(user, address(lon), 100);
-
-        assertEq(lon.balanceOf(address(this)), 100);
-    }
-
-    function testSpendFromUserWithNoReturnValueToken() public {
-        assertEq(noReturnERC20.balanceOf(address(this)), 0);
-
-        spender.spendFromUser(user, address(noReturnERC20), 100);
-
-        assertEq(noReturnERC20.balanceOf(address(this)), 100);
-    }
-
-    /*********************************
      *     Test: spendFromUserTo     *
      *********************************/
 


### PR DESCRIPTION
1. The spendFromUser() function in the Spender.sol contract was replaced by the new spendFromUserToWithPermit() function, so the spendFromUser() was removed and the associated Foundry Test was also removed.

2. Verify command:
```shell
DEPLOYED=false forge test -vvv --match-path 'contracts/test/Spender.t.sol'
```