### PR TITLE
remove unused const in SignatureValidator.sol

### DIFF
--- a/contracts/utils/SignatureValidator.sol
+++ b/contracts/utils/SignatureValidator.sol
@@ -30,9 +30,6 @@ contract SignatureValidator {
     // bytes4(keccak256("isValidSignature(bytes32,bytes)"))
     bytes4 internal constant ERC1271_MAGICVALUE_BYTES32 = 0x1626ba7e;
 
-    // keccak256("isValidWalletSignature(bytes32,address,bytes)")
-    bytes4 internal constant ERC1271_FALLBACK_MAGICVALUE_BYTES32 = 0xb0671381;
-
     // Allowed signature types.
     enum SignatureType {
         Illegal, // 0x00, default value


### PR DESCRIPTION
The `ERC1271_FALLBACK_MAGICVALUE_BYTES32` is not used in any place.