### PR TITLE
Remove foundry CI cache step

### DIFF
--- a/.github/workflows/tokenlon-contracts.yml
+++ b/.github/workflows/tokenlon-contracts.yml
@@ -17,11 +17,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: "Cache RPC Responses"
-        uses: "actions/cache@v3"
-        with:
-          path: "~/.foundry/cache/rpc/mainnet/"
-          key: "${{ runner.os }}-mainnet"
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
The caching step has been merged into foundry-toolchain: https://github.com/foundry-rs/foundry-toolchain/releases/tag/v1.0.8