### PR TITLE
Limitorder two-step set fee factors

### DIFF
--- a/contracts/LimitOrder.sol
+++ b/contracts/LimitOrder.sol
@@ -153,7 +153,7 @@ contract LimitOrder is ILimitOrder, BaseLibEIP712, SignatureValidator, Reentranc
         factorsTimeLock = block.timestamp + factorActivateDelay;
     }
 
-    function activateFactors() external onlyOperator {
+    function activateFactors() external {
         require(factorsTimeLock != 0, "LimitOrder: no pending fee factors");
         require(block.timestamp >= factorsTimeLock, "LimitOrder: fee factors timelocked");
         factorsTimeLock = 0;

--- a/contracts/LimitOrder.sol
+++ b/contracts/LimitOrder.sol
@@ -25,6 +25,7 @@ contract LimitOrder is ILimitOrder, BaseLibEIP712, SignatureValidator, Reentranc
     using SafeERC20 for IERC20;
 
     string public constant version = "1.0.0";
+    uint256 public immutable factorActivateDelay;
     IPermanentStorage public immutable permStorage;
     address public immutable userProxy;
     IWETH public immutable weth;
@@ -40,9 +41,13 @@ contract LimitOrder is ILimitOrder, BaseLibEIP712, SignatureValidator, Reentranc
     address public feeCollector;
 
     // Factors
+    uint256 public factorsTimeLock;
     uint16 public makerFeeFactor = 0;
+    uint16 public pendingMakerFeeFactor;
     uint16 public takerFeeFactor = 0;
+    uint16 public pendingTakerFeeFactor;
     uint16 public profitFeeFactor = 0;
+    uint16 public pendingProfitFeeFactor;
 
     constructor(
         address _operator,
@@ -51,6 +56,7 @@ contract LimitOrder is ILimitOrder, BaseLibEIP712, SignatureValidator, Reentranc
         ISpender _spender,
         IPermanentStorage _permStorage,
         IWETH _weth,
+        uint256 _factorActivateDelay,
         address _uniswapV3RouterAddress,
         address _sushiswapRouterAddress,
         address _feeCollector
@@ -61,6 +67,7 @@ contract LimitOrder is ILimitOrder, BaseLibEIP712, SignatureValidator, Reentranc
         spender = _spender;
         permStorage = _permStorage;
         weth = _weth;
+        factorActivateDelay = _factorActivateDelay;
         uniswapV3RouterAddress = _uniswapV3RouterAddress;
         sushiswapRouterAddress = _sushiswapRouterAddress;
         feeCollector = _feeCollector;
@@ -139,11 +146,25 @@ contract LimitOrder is ILimitOrder, BaseLibEIP712, SignatureValidator, Reentranc
         require(_takerFeeFactor <= LibConstant.BPS_MAX, "LimitOrder: Invalid taker fee factor");
         require(_profitFeeFactor <= LibConstant.BPS_MAX, "LimitOrder: Invalid profit fee factor");
 
-        makerFeeFactor = _makerFeeFactor;
-        takerFeeFactor = _takerFeeFactor;
-        profitFeeFactor = _profitFeeFactor;
+        pendingMakerFeeFactor = _makerFeeFactor;
+        pendingTakerFeeFactor = _takerFeeFactor;
+        pendingProfitFeeFactor = _profitFeeFactor;
 
-        emit FactorsUpdated(_makerFeeFactor, _takerFeeFactor, _profitFeeFactor);
+        factorsTimeLock = block.timestamp + factorActivateDelay;
+    }
+
+    function activateFactors() external onlyOperator {
+        require(factorsTimeLock != 0, "LimitOrder: no pending fee factors");
+        require(block.timestamp >= factorsTimeLock, "LimitOrder: fee factors timelocked");
+        factorsTimeLock = 0;
+        makerFeeFactor = pendingMakerFeeFactor;
+        takerFeeFactor = pendingTakerFeeFactor;
+        profitFeeFactor = pendingProfitFeeFactor;
+        pendingMakerFeeFactor = 0;
+        pendingTakerFeeFactor = 0;
+        pendingProfitFeeFactor = 0;
+
+        emit FactorsUpdated(makerFeeFactor, takerFeeFactor, profitFeeFactor);
     }
 
     /**

--- a/contracts/LimitOrder.sol
+++ b/contracts/LimitOrder.sol
@@ -137,7 +137,7 @@ contract LimitOrder is ILimitOrder, BaseLibEIP712, SignatureValidator, Reentranc
         }
     }
 
-    function setFactors(
+    function proposeFactors(
         uint16 _makerFeeFactor,
         uint16 _takerFeeFactor,
         uint16 _profitFeeFactor

--- a/contracts/test/forkMainnet/LimitOrder.t.sol
+++ b/contracts/test/forkMainnet/LimitOrder.t.sol
@@ -179,6 +179,7 @@ contract LimitOrderTest is StrategySharedSetup {
         assertEq(limitOrder.uniswapV3RouterAddress(), UNISWAP_V3_ADDRESS);
         assertEq(limitOrder.sushiswapRouterAddress(), SUSHISWAP_ADDRESS);
 
+        assertEq(limitOrder.factorActivateDelay(), FACTORSDEALY);
         assertEq(uint256(limitOrder.makerFeeFactor()), 0);
         assertEq(uint256(limitOrder.takerFeeFactor()), 0);
         assertEq(uint256(limitOrder.profitFeeFactor()), 0);
@@ -291,20 +292,20 @@ contract LimitOrderTest is StrategySharedSetup {
     }
 
     /*********************************
-     *        Test: setFactors       *
+     *        Test: proposeFactors       *
      *********************************/
 
     function testCannotSetFactorsIfLargerThanBpsMax() public {
         vm.expectRevert("LimitOrder: Invalid maker fee factor");
-        limitOrder.setFactors(LibConstant.BPS_MAX + 1, 1, 1);
+        limitOrder.proposeFactors(LibConstant.BPS_MAX + 1, 1, 1);
         vm.expectRevert("LimitOrder: Invalid taker fee factor");
-        limitOrder.setFactors(1, LibConstant.BPS_MAX + 1, 1);
+        limitOrder.proposeFactors(1, LibConstant.BPS_MAX + 1, 1);
         vm.expectRevert("LimitOrder: Invalid profit fee factor");
-        limitOrder.setFactors(1, 1, LibConstant.BPS_MAX + 1);
+        limitOrder.proposeFactors(1, 1, LibConstant.BPS_MAX + 1);
     }
 
     function testSetFactors() public {
-        limitOrder.setFactors(1, 2, 3);
+        limitOrder.proposeFactors(1, 2, 3);
         // fee factors should stay same before new ones activate
         assertEq(uint256(limitOrder.makerFeeFactor()), 0);
         assertEq(uint256(limitOrder.takerFeeFactor()), 0);
@@ -602,7 +603,7 @@ contract LimitOrderTest is StrategySharedSetup {
 
         // makerFeeFactor/takerFeeFactor : 10%
         // profitFeeFactor : 20%
-        limitOrder.setFactors(1000, 1000, 2000);
+        limitOrder.proposeFactors(1000, 1000, 2000);
         vm.warp(block.timestamp + limitOrder.factorActivateDelay());
         limitOrder.activateFactors();
 
@@ -1004,7 +1005,7 @@ contract LimitOrderTest is StrategySharedSetup {
 
         // makerFeeFactor/takerFeeFactor : 10%
         // profitFeeFactor : 20%
-        limitOrder.setFactors(1000, 1000, 2000);
+        limitOrder.proposeFactors(1000, 1000, 2000);
         vm.warp(block.timestamp + limitOrder.factorActivateDelay());
         limitOrder.activateFactors();
 

--- a/contracts/test/forkMainnet/LimitOrder.t.sol
+++ b/contracts/test/forkMainnet/LimitOrder.t.sol
@@ -71,6 +71,7 @@ contract LimitOrderTest is StrategySharedSetup {
 
     LimitOrder limitOrder;
     uint64 DEADLINE = uint64(block.timestamp + 2 days);
+    uint256 FACTORSDEALY = 12 hours;
 
     // effectively a "beforeEach" block
     function setUp() public {
@@ -149,6 +150,7 @@ contract LimitOrderTest is StrategySharedSetup {
             ISpender(address(spender)),
             IPermanentStorage(address(permanentStorage)),
             IWETH(address(weth)),
+            FACTORSDEALY,
             UNISWAP_V3_ADDRESS,
             SUSHISWAP_ADDRESS,
             feeCollector
@@ -303,6 +305,14 @@ contract LimitOrderTest is StrategySharedSetup {
 
     function testSetFactors() public {
         limitOrder.setFactors(1, 2, 3);
+        // fee factors should stay same before new ones activate
+        assertEq(uint256(limitOrder.makerFeeFactor()), 0);
+        assertEq(uint256(limitOrder.takerFeeFactor()), 0);
+        assertEq(uint256(limitOrder.profitFeeFactor()), 0);
+        vm.warp(block.timestamp + limitOrder.factorActivateDelay());
+
+        // fee factors should be updated now
+        limitOrder.activateFactors();
         assertEq(uint256(limitOrder.makerFeeFactor()), 1);
         assertEq(uint256(limitOrder.takerFeeFactor()), 2);
         assertEq(uint256(limitOrder.profitFeeFactor()), 3);
@@ -593,6 +603,8 @@ contract LimitOrderTest is StrategySharedSetup {
         // makerFeeFactor/takerFeeFactor : 10%
         // profitFeeFactor : 20%
         limitOrder.setFactors(1000, 1000, 2000);
+        vm.warp(block.timestamp + limitOrder.factorActivateDelay());
+        limitOrder.activateFactors();
 
         bytes memory payload = _genFillByTraderPayload(DEFAULT_ORDER, DEFAULT_ORDER_MAKER_SIG, DEFAULT_TRADER_PARAMS, DEFAULT_CRD_PARAMS);
         vm.expectEmit(true, true, true, true);
@@ -993,6 +1005,8 @@ contract LimitOrderTest is StrategySharedSetup {
         // makerFeeFactor/takerFeeFactor : 10%
         // profitFeeFactor : 20%
         limitOrder.setFactors(1000, 1000, 2000);
+        vm.warp(block.timestamp + limitOrder.factorActivateDelay());
+        limitOrder.activateFactors();
 
         // get quote from AMM
         uint256 ammTakerTokenOut = quoteUniswapV3ExactInput(DEFAULT_PROTOCOL_PARAMS.data, DEFAULT_ORDER.makerTokenAmount);


### PR DESCRIPTION
Introduce two-step fee factor updating process to LimitOrder contract. If the operator set feeFactor to 100% or some unacceptable percentage, user can cancel their orders within the timelock period.