### PR TITLE
Check required address not zero in each tests

### DIFF
--- a/test/RFQ.t.sol
+++ b/test/RFQ.t.sol
@@ -55,7 +55,6 @@ contract RFQTest is StrategySharedSetup {
     function setUp() public {
         // Setup
         if (!vm.envBool("DEPLOYED")) {
-            // overwrite tokens with locally deployed mocks
             tokens = [weth, usdt, dai];
         }
         setUpSystemContracts();

--- a/test/forkMainnet/AMMQuoter.t.sol
+++ b/test/forkMainnet/AMMQuoter.t.sol
@@ -45,9 +45,10 @@ contract AMMQuoterTest is StrategySharedSetup {
         vm.label(address(this), "TestingContract");
         vm.label(address(ammQuoter), "AMMQuoterContract");
         vm.label(UNISWAP_V2_ADDRESS, "UniswapV2");
-        vm.label(SUSHISWAP_ADDRESS, "Sushiswap");
         vm.label(UNISWAP_V3_ADDRESS, "UniswapV3");
         vm.label(UNISWAP_V3_QUOTER_ADDRESS, "UniswapV3Quoter");
+        vm.label(SUSHISWAP_ADDRESS, "Sushiswap");
+        vm.label(BALANCER_V2_ADDRESS, "Balancer");
     }
 
     /*********************************
@@ -55,6 +56,16 @@ contract AMMQuoterTest is StrategySharedSetup {
      *********************************/
 
     function testSetupAMMQuoter() public {
+        // Check fork mainnet addresses are not zero addresses
+        assertTrue(uint160(UNISWAP_V2_ADDRESS) != 0);
+        assertTrue(uint160(UNISWAP_V3_ADDRESS) != 0);
+        assertTrue(uint160(UNISWAP_V3_QUOTER_ADDRESS) != 0);
+        assertTrue(uint160(SUSHISWAP_ADDRESS) != 0);
+        assertTrue(uint160(BALANCER_V2_ADDRESS) != 0);
+        assertTrue(uint160(WETH_ADDRESS) != 0);
+        assertTrue(uint160(DAI_ADDRESS) != 0);
+        assertTrue(uint160(USDT_ADDRESS) != 0);
+
         assertEq(address(ammQuoter.permStorage()), address(permanentStorage));
         assertEq(ammQuoter.weth(), WETH_ADDRESS);
     }

--- a/test/forkMainnet/AMMQuoter.t.sol
+++ b/test/forkMainnet/AMMQuoter.t.sol
@@ -57,14 +57,14 @@ contract AMMQuoterTest is StrategySharedSetup {
 
     function testSetupAMMQuoter() public {
         // Check fork mainnet addresses are not zero addresses
-        assertTrue(uint160(UNISWAP_V2_ADDRESS) != 0);
-        assertTrue(uint160(UNISWAP_V3_ADDRESS) != 0);
-        assertTrue(uint160(UNISWAP_V3_QUOTER_ADDRESS) != 0);
-        assertTrue(uint160(SUSHISWAP_ADDRESS) != 0);
-        assertTrue(uint160(BALANCER_V2_ADDRESS) != 0);
-        assertTrue(uint160(WETH_ADDRESS) != 0);
-        assertTrue(uint160(DAI_ADDRESS) != 0);
-        assertTrue(uint160(USDT_ADDRESS) != 0);
+        assertTrue(UNISWAP_V2_ADDRESS != address(0));
+        assertTrue(UNISWAP_V3_ADDRESS != address(0));
+        assertTrue(UNISWAP_V3_QUOTER_ADDRESS != address(0));
+        assertTrue(SUSHISWAP_ADDRESS != address(0));
+        assertTrue(BALANCER_V2_ADDRESS != address(0));
+        assertTrue(WETH_ADDRESS != address(0));
+        assertTrue(DAI_ADDRESS != address(0));
+        assertTrue(USDT_ADDRESS != address(0));
 
         assertEq(address(ammQuoter.permStorage()), address(permanentStorage));
         assertEq(ammQuoter.weth(), WETH_ADDRESS);

--- a/test/forkMainnet/AMMWrapper/Setup.t.sol
+++ b/test/forkMainnet/AMMWrapper/Setup.t.sol
@@ -59,6 +59,7 @@ contract TestAMMWrapper is StrategySharedSetup {
         // Deal 100 ETH to each account
         dealWallet(wallet, 100 ether);
         // Set token balance and approve
+        tokens = [weth, usdt, dai, ankreth];
         setEOABalanceAndApprove(user, tokens, uint256(100));
 
         // Default order
@@ -76,10 +77,17 @@ contract TestAMMWrapper is StrategySharedSetup {
 
         // Label addresses for easier debugging
         vm.label(user, "User");
+        vm.label(owner, "Owner");
+        vm.label(feeCollector, "FeeCollector");
         vm.label(relayer, "Relayer");
         vm.label(address(this), "TestingContract");
+        vm.label(address(ammQuoter), "AMMQuoterContract");
         vm.label(address(ammWrapper), "AMMWrapperContract");
         vm.label(UNISWAP_V2_ADDRESS, "UniswapV2");
+        vm.label(SUSHISWAP_ADDRESS, "Sushiswap");
+        vm.label(UNISWAP_V3_ADDRESS, "UniswapV3");
+        vm.label(CURVE_USDT_POOL_ADDRESS, "CurveUSDTPool");
+        vm.label(CURVE_TRICRYPTO2_POOL_ADDRESS, "CurveTriCryptoPool");
     }
 
     // Deploy the strategy contract by overriding the StrategySharedSetup.sol deployment function

--- a/test/forkMainnet/AMMWrapper/SetupTest.t.sol
+++ b/test/forkMainnet/AMMWrapper/SetupTest.t.sol
@@ -11,6 +11,18 @@ contract TestAMMWrapperSetup is TestAMMWrapper {
     }
 
     function testAMMWrapperSetup() public {
+        // Check fork mainnet addresses are not zero addresses
+        assertTrue(uint160(UNISWAP_V2_ADDRESS) != 0);
+        assertTrue(uint160(UNISWAP_V3_ADDRESS) != 0);
+        assertTrue(uint160(UNISWAP_V3_QUOTER_ADDRESS) != 0);
+        assertTrue(uint160(SUSHISWAP_ADDRESS) != 0);
+        assertTrue(uint160(BALANCER_V2_ADDRESS) != 0);
+        assertTrue(uint160(CURVE_ANKRETH_POOL_ADDRESS) != 0);
+        assertTrue(uint160(WETH_ADDRESS) != 0);
+        assertTrue(uint160(DAI_ADDRESS) != 0);
+        assertTrue(uint160(USDT_ADDRESS) != 0);
+        assertTrue(uint160(ANKRETH_ADDRESS) != 0);
+
         assertEq(ammWrapper.owner(), owner);
         assertEq(uint256(ammWrapper.defaultFeeFactor()), uint256(DEFAULT_FEE_FACTOR));
         assertEq(ammWrapper.userProxy(), address(userProxy));

--- a/test/forkMainnet/AMMWrapper/SetupTest.t.sol
+++ b/test/forkMainnet/AMMWrapper/SetupTest.t.sol
@@ -12,16 +12,16 @@ contract TestAMMWrapperSetup is TestAMMWrapper {
 
     function testAMMWrapperSetup() public {
         // Check fork mainnet addresses are not zero addresses
-        assertTrue(uint160(UNISWAP_V2_ADDRESS) != 0);
-        assertTrue(uint160(UNISWAP_V3_ADDRESS) != 0);
-        assertTrue(uint160(UNISWAP_V3_QUOTER_ADDRESS) != 0);
-        assertTrue(uint160(SUSHISWAP_ADDRESS) != 0);
-        assertTrue(uint160(BALANCER_V2_ADDRESS) != 0);
-        assertTrue(uint160(CURVE_ANKRETH_POOL_ADDRESS) != 0);
-        assertTrue(uint160(WETH_ADDRESS) != 0);
-        assertTrue(uint160(DAI_ADDRESS) != 0);
-        assertTrue(uint160(USDT_ADDRESS) != 0);
-        assertTrue(uint160(ANKRETH_ADDRESS) != 0);
+        assertTrue(UNISWAP_V2_ADDRESS != address(0));
+        assertTrue(UNISWAP_V3_ADDRESS != address(0));
+        assertTrue(UNISWAP_V3_QUOTER_ADDRESS != address(0));
+        assertTrue(SUSHISWAP_ADDRESS != address(0));
+        assertTrue(BALANCER_V2_ADDRESS != address(0));
+        assertTrue(CURVE_ANKRETH_POOL_ADDRESS != address(0));
+        assertTrue(WETH_ADDRESS != address(0));
+        assertTrue(DAI_ADDRESS != address(0));
+        assertTrue(USDT_ADDRESS != address(0));
+        assertTrue(ANKRETH_ADDRESS != address(0));
 
         assertEq(ammWrapper.owner(), owner);
         assertEq(uint256(ammWrapper.defaultFeeFactor()), uint256(DEFAULT_FEE_FACTOR));

--- a/test/forkMainnet/AMMWrapperWithPath/Setup.t.sol
+++ b/test/forkMainnet/AMMWrapperWithPath/Setup.t.sol
@@ -68,6 +68,7 @@ contract TestAMMWrapperWithPath is StrategySharedSetup {
         // Deal 100 ETH to each account
         dealWallet(wallet, 100 ether);
         // Set token balance and approve
+        tokens = [weth, usdc, usdt, dai, wbtc, lon];
         setEOABalanceAndApprove(user, tokens, uint256(100));
 
         // Default order
@@ -92,8 +93,11 @@ contract TestAMMWrapperWithPath is StrategySharedSetup {
 
         // Label addresses for easier debugging
         vm.label(user, "User");
+        vm.label(owner, "Owner");
+        vm.label(feeCollector, "FeeCollector");
         vm.label(relayer, "Relayer");
         vm.label(address(this), "TestingContract");
+        vm.label(address(ammQuoter), "AMMQuoterContract");
         vm.label(address(ammWrapperWithPath), "AMMWrapperWithPathContract");
         vm.label(UNISWAP_V2_ADDRESS, "UniswapV2");
         vm.label(SUSHISWAP_ADDRESS, "Sushiswap");

--- a/test/forkMainnet/AMMWrapperWithPath/SetupTest.t.sol
+++ b/test/forkMainnet/AMMWrapperWithPath/SetupTest.t.sol
@@ -12,6 +12,20 @@ contract TestAMMWrapperWithPathSetup is TestAMMWrapperWithPath {
     }
 
     function testAMMWrapperWithPathSetup() public {
+        // Check fork mainnet addresses are not zero addresses
+        assertTrue(uint160(UNISWAP_V2_ADDRESS) != 0);
+        assertTrue(uint160(UNISWAP_V3_ADDRESS) != 0);
+        assertTrue(uint160(UNISWAP_V3_QUOTER_ADDRESS) != 0);
+        assertTrue(uint160(SUSHISWAP_ADDRESS) != 0);
+        assertTrue(uint160(BALANCER_V2_ADDRESS) != 0);
+        assertTrue(uint160(CURVE_USDT_POOL_ADDRESS) != 0);
+        assertTrue(uint160(CURVE_TRICRYPTO2_POOL_ADDRESS) != 0);
+        assertTrue(uint160(WETH_ADDRESS) != 0);
+        assertTrue(uint160(DAI_ADDRESS) != 0);
+        assertTrue(uint160(USDT_ADDRESS) != 0);
+        assertTrue(uint160(USDC_ADDRESS) != 0);
+        assertTrue(uint160(WBTC_ADDRESS) != 0);
+
         assertEq(ammWrapperWithPath.owner(), owner);
         assertEq(uint256(ammWrapperWithPath.defaultFeeFactor()), uint256(DEFAULT_FEE_FACTOR));
         assertEq(ammWrapperWithPath.userProxy(), address(userProxy));

--- a/test/forkMainnet/AMMWrapperWithPath/SetupTest.t.sol
+++ b/test/forkMainnet/AMMWrapperWithPath/SetupTest.t.sol
@@ -13,18 +13,18 @@ contract TestAMMWrapperWithPathSetup is TestAMMWrapperWithPath {
 
     function testAMMWrapperWithPathSetup() public {
         // Check fork mainnet addresses are not zero addresses
-        assertTrue(uint160(UNISWAP_V2_ADDRESS) != 0);
-        assertTrue(uint160(UNISWAP_V3_ADDRESS) != 0);
-        assertTrue(uint160(UNISWAP_V3_QUOTER_ADDRESS) != 0);
-        assertTrue(uint160(SUSHISWAP_ADDRESS) != 0);
-        assertTrue(uint160(BALANCER_V2_ADDRESS) != 0);
-        assertTrue(uint160(CURVE_USDT_POOL_ADDRESS) != 0);
-        assertTrue(uint160(CURVE_TRICRYPTO2_POOL_ADDRESS) != 0);
-        assertTrue(uint160(WETH_ADDRESS) != 0);
-        assertTrue(uint160(DAI_ADDRESS) != 0);
-        assertTrue(uint160(USDT_ADDRESS) != 0);
-        assertTrue(uint160(USDC_ADDRESS) != 0);
-        assertTrue(uint160(WBTC_ADDRESS) != 0);
+        assertTrue(UNISWAP_V2_ADDRESS != address(0));
+        assertTrue(UNISWAP_V3_ADDRESS != address(0));
+        assertTrue(UNISWAP_V3_QUOTER_ADDRESS != address(0));
+        assertTrue(SUSHISWAP_ADDRESS != address(0));
+        assertTrue(BALANCER_V2_ADDRESS != address(0));
+        assertTrue(CURVE_USDT_POOL_ADDRESS != address(0));
+        assertTrue(CURVE_TRICRYPTO2_POOL_ADDRESS != address(0));
+        assertTrue(WETH_ADDRESS != address(0));
+        assertTrue(DAI_ADDRESS != address(0));
+        assertTrue(USDT_ADDRESS != address(0));
+        assertTrue(USDC_ADDRESS != address(0));
+        assertTrue(WBTC_ADDRESS != address(0));
 
         assertEq(ammWrapperWithPath.owner(), owner);
         assertEq(uint256(ammWrapperWithPath.defaultFeeFactor()), uint256(DEFAULT_FEE_FACTOR));

--- a/test/forkMainnet/L2Deposit/Setup.t.sol
+++ b/test/forkMainnet/L2Deposit/Setup.t.sol
@@ -58,6 +58,7 @@ contract TestL2Deposit is StrategySharedSetup {
         arbitrumLONAddr = IERC20(arbitrumL1GatewayRouter.calculateL2TokenAddress(address(lon)));
 
         // Set user token balance and approve
+        tokens = [lon];
         setEOABalanceAndApprove(user, tokens, 100);
 
         DEFAULT_DEPOSIT = L2DepositLibEIP712.Deposit(
@@ -74,7 +75,12 @@ contract TestL2Deposit is StrategySharedSetup {
 
         // Label addresses for easier debugging
         vm.label(user, "User");
+        vm.label(owner, "Owner");
         vm.label(address(this), "TestingContract");
+        vm.label(address(l2Deposit), "L2DepositContract");
+        vm.label(address(arbitrumL1GatewayRouter), "ArbitrumL1GatewayContract");
+        vm.label(address(arbitrumL1Bridge), "ArbitrumL1BridgeContract");
+        vm.label(address(optimismL1StandardBridge), "OptimismL1StandardBridgeContract");
     }
 
     function _deployStrategyAndUpgrade() internal override returns (address) {

--- a/test/forkMainnet/L2Deposit/SetupTest.t.sol
+++ b/test/forkMainnet/L2Deposit/SetupTest.t.sol
@@ -5,6 +5,16 @@ import "test/forkMainnet/L2Deposit/Setup.t.sol";
 
 contract TestL2DepositSetup is TestL2Deposit {
     function testSetupL2Deposit() public {
+        // Check fork mainnet addresses are not zero addresses
+        assertTrue(uint160(ARBITRUM_L1_GATEWAY_ROUTER_ADDR) != 0);
+        assertTrue(uint160(ARBITRUM_L1_BRIDGE_ADDR) != 0);
+        assertTrue(uint160(OPTIMISM_L1_STANDARD_BRIDGE_ADDR) != 0);
+        assertTrue(uint160(WETH_ADDRESS) != 0);
+        assertTrue(uint160(DAI_ADDRESS) != 0);
+        assertTrue(uint160(USDT_ADDRESS) != 0);
+        assertTrue(uint160(USDC_ADDRESS) != 0);
+        assertTrue(uint160(LON_ADDRESS) != 0);
+
         assertEq(l2Deposit.owner(), owner);
         assertEq(l2Deposit.userProxy(), address(userProxy));
         assertEq(address(l2Deposit.spender()), address(spender));

--- a/test/forkMainnet/L2Deposit/SetupTest.t.sol
+++ b/test/forkMainnet/L2Deposit/SetupTest.t.sol
@@ -6,14 +6,14 @@ import "test/forkMainnet/L2Deposit/Setup.t.sol";
 contract TestL2DepositSetup is TestL2Deposit {
     function testSetupL2Deposit() public {
         // Check fork mainnet addresses are not zero addresses
-        assertTrue(uint160(ARBITRUM_L1_GATEWAY_ROUTER_ADDR) != 0);
-        assertTrue(uint160(ARBITRUM_L1_BRIDGE_ADDR) != 0);
-        assertTrue(uint160(OPTIMISM_L1_STANDARD_BRIDGE_ADDR) != 0);
-        assertTrue(uint160(WETH_ADDRESS) != 0);
-        assertTrue(uint160(DAI_ADDRESS) != 0);
-        assertTrue(uint160(USDT_ADDRESS) != 0);
-        assertTrue(uint160(USDC_ADDRESS) != 0);
-        assertTrue(uint160(LON_ADDRESS) != 0);
+        assertTrue(ARBITRUM_L1_GATEWAY_ROUTER_ADDR != address(0));
+        assertTrue(ARBITRUM_L1_BRIDGE_ADDR != address(0));
+        assertTrue(OPTIMISM_L1_STANDARD_BRIDGE_ADDR != address(0));
+        assertTrue(WETH_ADDRESS != address(0));
+        assertTrue(DAI_ADDRESS != address(0));
+        assertTrue(USDT_ADDRESS != address(0));
+        assertTrue(USDC_ADDRESS != address(0));
+        assertTrue(LON_ADDRESS != address(0));
 
         assertEq(l2Deposit.owner(), owner);
         assertEq(l2Deposit.userProxy(), address(userProxy));

--- a/test/forkMainnet/LimitOrder.t.sol
+++ b/test/forkMainnet/LimitOrder.t.sol
@@ -55,8 +55,9 @@ contract LimitOrderTest is StrategySharedSetup {
     address receiver = makeAddr("receiver");
     MockERC1271Wallet mockERC1271Wallet = new MockERC1271Wallet(user);
     address[] wallet = [user, maker, coordinator, address(mockERC1271Wallet)];
-    address[] tokenAddrs;
+    address[] allowanceAddrs;
 
+    address[] DEFAULT_AMM_PATH;
     LimitOrderLibEIP712.Order DEFAULT_ORDER;
     bytes32 DEFAULT_ORDER_HASH;
     bytes DEFAULT_ORDER_MAKER_SIG;
@@ -74,7 +75,8 @@ contract LimitOrderTest is StrategySharedSetup {
         // Setup
         setUpSystemContracts();
 
-        tokenAddrs = [address(dai), address(usdt)];
+        DEFAULT_AMM_PATH = [address(dai), address(usdt)];
+        allowanceAddrs = DEFAULT_AMM_PATH;
 
         // Default params
         DEFAULT_ORDER = LimitOrderLibEIP712.Order(
@@ -122,6 +124,7 @@ contract LimitOrderTest is StrategySharedSetup {
         // Deal 100 ETH to each account
         dealWallet(wallet, 100 ether);
         // Set token balance and approve
+        tokens = [weth, usdt, dai];
         setEOABalanceAndApprove(user, tokens, 10000);
         setEOABalanceAndApprove(maker, tokens, 10000);
         setEOABalanceAndApprove(address(mockERC1271Wallet), tokens, 10000);
@@ -135,9 +138,6 @@ contract LimitOrderTest is StrategySharedSetup {
         vm.label(address(this), "TestingContract");
         vm.label(address(limitOrder), "LimitOrderContract");
         vm.label(address(mockERC1271Wallet), "MockERC1271Wallet");
-        vm.label(address(weth), "WETH");
-        vm.label(address(usdt), "USDT");
-        vm.label(address(dai), "DAI");
     }
 
     function _deployStrategyAndUpgrade() internal override returns (address) {
@@ -178,6 +178,14 @@ contract LimitOrderTest is StrategySharedSetup {
      *********************************/
 
     function testSetupLimitOrder() public {
+        // Check fork mainnet addresses are not zero addresses
+        assertTrue(uint160(UNISWAP_V3_ADDRESS) != 0);
+        assertTrue(uint160(UNISWAP_V3_QUOTER_ADDRESS) != 0);
+        assertTrue(uint160(SUSHISWAP_ADDRESS) != 0);
+        assertTrue(uint160(WETH_ADDRESS) != 0);
+        assertTrue(uint160(DAI_ADDRESS) != 0);
+        assertTrue(uint160(USDT_ADDRESS) != 0);
+
         assertEq(limitOrder.owner(), owner);
         assertEq(limitOrder.coordinator(), coordinator);
         assertEq(limitOrder.userProxy(), address(userProxy));
@@ -267,25 +275,25 @@ contract LimitOrderTest is StrategySharedSetup {
     function testCannotSetAllowanceByNotOwner() public {
         vm.expectRevert("not owner");
         vm.prank(user);
-        limitOrder.setAllowance(tokenAddrs, address(allowanceTarget));
+        limitOrder.setAllowance(allowanceAddrs, address(allowanceTarget));
     }
 
     function testCannotCloseAllowanceByNotOwner() public {
         vm.expectRevert("not owner");
         vm.prank(user);
-        limitOrder.closeAllowance(tokenAddrs, address(allowanceTarget));
+        limitOrder.closeAllowance(allowanceAddrs, address(allowanceTarget));
     }
 
     function testSetAndCloseAllowance() public {
         // Set allowance
         vm.prank(owner, owner);
-        limitOrder.setAllowance(tokenAddrs, address(allowanceTarget));
+        limitOrder.setAllowance(allowanceAddrs, address(allowanceTarget));
         assertEq(usdt.allowance(address(limitOrder), address(allowanceTarget)), LibConstant.MAX_UINT);
         assertEq(dai.allowance(address(limitOrder), address(allowanceTarget)), LibConstant.MAX_UINT);
 
         // Close allowance
         vm.prank(owner, owner);
-        limitOrder.closeAllowance(tokenAddrs, address(allowanceTarget));
+        limitOrder.closeAllowance(allowanceAddrs, address(allowanceTarget));
         assertEq(usdt.allowance(address(limitOrder), address(allowanceTarget)), 0);
         assertEq(dai.allowance(address(limitOrder), address(allowanceTarget)), 0);
     }
@@ -821,9 +829,9 @@ contract LimitOrderTest is StrategySharedSetup {
 
     function testCannotFillBySushiSwapLessThanProtocolOutMinimum() public {
         // get quote from AMM
-        uint256[] memory amountOuts = getSushiAmountsOut(SUSHISWAP_ADDRESS, DEFAULT_ORDER.makerTokenAmount, tokenAddrs);
+        uint256[] memory amountOuts = getSushiAmountsOut(SUSHISWAP_ADDRESS, DEFAULT_ORDER.makerTokenAmount, DEFAULT_AMM_PATH);
 
-        address[] memory path = tokenAddrs;
+        address[] memory path = DEFAULT_AMM_PATH;
         ILimitOrder.ProtocolParams memory protocolParams = DEFAULT_PROTOCOL_PARAMS;
         protocolParams.protocol = ILimitOrder.Protocol.Sushiswap;
         protocolParams.protocolOutMinimum = amountOuts[1].mul(2); // require 2x output from AMM
@@ -1165,7 +1173,7 @@ contract LimitOrderTest is StrategySharedSetup {
         order.takerTokenAmount = 8 * 1e6;
 
         // get quote from AMM
-        address[] memory path = tokenAddrs;
+        address[] memory path = DEFAULT_AMM_PATH;
         uint256[] memory amountOuts = getSushiAmountsOut(SUSHISWAP_ADDRESS, order.makerTokenAmount, path);
         // Since profitFeeFactor is zero, so the extra token from AMM is the profit for relayer.
         uint256 profit = amountOuts[amountOuts.length - 1].sub(order.takerTokenAmount);

--- a/test/forkMainnet/LimitOrder.t.sol
+++ b/test/forkMainnet/LimitOrder.t.sol
@@ -179,12 +179,12 @@ contract LimitOrderTest is StrategySharedSetup {
 
     function testSetupLimitOrder() public {
         // Check fork mainnet addresses are not zero addresses
-        assertTrue(uint160(UNISWAP_V3_ADDRESS) != 0);
-        assertTrue(uint160(UNISWAP_V3_QUOTER_ADDRESS) != 0);
-        assertTrue(uint160(SUSHISWAP_ADDRESS) != 0);
-        assertTrue(uint160(WETH_ADDRESS) != 0);
-        assertTrue(uint160(DAI_ADDRESS) != 0);
-        assertTrue(uint160(USDT_ADDRESS) != 0);
+        assertTrue(UNISWAP_V3_ADDRESS != address(0));
+        assertTrue(UNISWAP_V3_QUOTER_ADDRESS != address(0));
+        assertTrue(SUSHISWAP_ADDRESS != address(0));
+        assertTrue(WETH_ADDRESS != address(0));
+        assertTrue(DAI_ADDRESS != address(0));
+        assertTrue(USDT_ADDRESS != address(0));
 
         assertEq(limitOrder.owner(), owner);
         assertEq(limitOrder.coordinator(), coordinator);

--- a/test/forkMainnet/RewardDistributor.t.sol
+++ b/test/forkMainnet/RewardDistributor.t.sol
@@ -164,13 +164,13 @@ contract RewardDistributorTest is Addresses {
 
     function testSetup() public {
         // Check fork mainnet addresses are not zero addresses
-        assertTrue(uint160(UNISWAP_V2_ADDRESS) != 0);
-        assertTrue(uint160(UNISWAP_V3_ADDRESS) != 0);
-        assertTrue(uint160(UNISWAP_V3_QUOTER_ADDRESS) != 0);
-        assertTrue(uint160(SUSHISWAP_ADDRESS) != 0);
-        assertTrue(uint160(LON_ADDRESS) != 0);
-        assertTrue(uint160(CRV_ADDRESS) != 0);
-        assertTrue(uint160(USDT_ADDRESS) != 0);
+        assertTrue(UNISWAP_V2_ADDRESS != address(0));
+        assertTrue(UNISWAP_V3_ADDRESS != address(0));
+        assertTrue(UNISWAP_V3_QUOTER_ADDRESS != address(0));
+        assertTrue(SUSHISWAP_ADDRESS != address(0));
+        assertTrue(LON_ADDRESS != address(0));
+        assertTrue(CRV_ADDRESS != address(0));
+        assertTrue(USDT_ADDRESS != address(0));
 
         address minter = lon.minter();
         assertEq(minter, address(rewardDistributor));

--- a/test/forkMainnet/RewardDistributor.t.sol
+++ b/test/forkMainnet/RewardDistributor.t.sol
@@ -154,8 +154,6 @@ contract RewardDistributorTest is Addresses {
         vm.label(address(sushiswap), "Sushiswap");
         vm.label(address(uniswapV3), "UniswapV3");
         vm.label(address(uniswapV3Quoter), "UniswapV3Quoter");
-        vm.label(address(usdt), "USDT");
-        vm.label(address(lon), "LON");
         vm.label(address(lonStaking), "LONStaking");
         vm.label(address(rewardDistributor), "RewardDistributor");
     }
@@ -165,6 +163,15 @@ contract RewardDistributorTest is Addresses {
      *********************************/
 
     function testSetup() public {
+        // Check fork mainnet addresses are not zero addresses
+        assertTrue(uint160(UNISWAP_V2_ADDRESS) != 0);
+        assertTrue(uint160(UNISWAP_V3_ADDRESS) != 0);
+        assertTrue(uint160(UNISWAP_V3_QUOTER_ADDRESS) != 0);
+        assertTrue(uint160(SUSHISWAP_ADDRESS) != 0);
+        assertTrue(uint160(LON_ADDRESS) != 0);
+        assertTrue(uint160(CRV_ADDRESS) != 0);
+        assertTrue(uint160(USDT_ADDRESS) != 0);
+
         address minter = lon.minter();
         assertEq(minter, address(rewardDistributor));
     }


### PR DESCRIPTION
Check used addresses are not zero addresses and update used tokens during `setup` in each test.