### PR TITLE
`BalanceUtil` not inherit `Addresses`

### DIFF
--- a/test/utils/BalanceUtil.sol
+++ b/test/utils/BalanceUtil.sol
@@ -7,12 +7,26 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 contract BalanceUtil is Test {
     using stdStorage for StdStorage;
 
+    function externalDeal(
+        address tokenAddr,
+        address userAddr,
+        uint256 amountInWei,
+        bool updateTotalSupply
+    ) public {
+        deal(tokenAddr, userAddr, amountInWei, updateTotalSupply);
+    }
+
     function setERC20Balance(
         address tokenAddr,
         address userAddr,
         uint256 amount
     ) internal {
         uint256 decimals = uint256(ERC20(tokenAddr).decimals());
-        deal(tokenAddr, userAddr, amount * (10**decimals), isFork() ? false : true);
+        uint256 amountInWei = amount * (10**decimals);
+        // First try to update `totalSupply` together, but this would fail with WETH because WETH does not store `totalSupply` in storage
+        try this.externalDeal(tokenAddr, userAddr, amountInWei, true) {} catch {
+            // If it fails, try again without update `totalSupply`
+            deal(tokenAddr, userAddr, amountInWei, false);
+        }
     }
 }

--- a/test/utils/BalanceUtil.sol
+++ b/test/utils/BalanceUtil.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.7.6;
 
+import "forge-std/Test.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "test/utils/Addresses.sol";
 
-contract BalanceUtil is Addresses {
+contract BalanceUtil is Test {
     using stdStorage for StdStorage;
 
     function setERC20Balance(
@@ -13,13 +13,6 @@ contract BalanceUtil is Addresses {
         uint256 amount
     ) internal {
         uint256 decimals = uint256(ERC20(tokenAddr).decimals());
-        // Skip setting WETH's totalSupply because WETH does not store total supply in storage
-        bool updateTotalSupply = tokenAddr == WETH_ADDRESS ? false : true;
-        deal(
-            tokenAddr,
-            userAddr,
-            amount * (10**decimals),
-            updateTotalSupply // also update totalSupply
-        );
+        deal(tokenAddr, userAddr, amount * (10**decimals), isFork() ? false : true);
     }
 }


### PR DESCRIPTION
Approach 1 (48edaee). `setERC20Balance` update `totalSupply` in local, not in fork
Approach 2 (85af8fa). try catch if `totalSupply` can be update regardless of fork