### PR TITLE
RFQv2 skip transfer if to address is this

### DIFF
--- a/contracts/utils/Asset.sol
+++ b/contracts/utils/Asset.sol
@@ -18,6 +18,9 @@ library Asset {
         address payable to,
         uint256 amount
     ) internal {
+        if (to == address(this)) {
+            return;
+        }
         if (isETH(asset)) {
             // @dev forward all available gas and may cause reentrancy
             require(address(this).balance >= amount, "insufficient balance");

--- a/test/forkMainnet/RFQv2.t.sol
+++ b/test/forkMainnet/RFQv2.t.sol
@@ -39,7 +39,7 @@ contract RFQTest is StrategySharedSetup {
     address payable maker = payable(vm.addr(makerPrivateKey));
     uint256 takerPrivateKey = uint256(1);
     address taker = vm.addr(takerPrivateKey);
-    address payable recipient = payable(makeAddr("recipient"));
+    address payable recipient;
     address payable feeCollector = payable(makeAddr("feeCollector"));
     uint256 defaultExpiry = block.timestamp + 1;
     uint256 defaultSalt = 1234;
@@ -56,6 +56,8 @@ contract RFQTest is StrategySharedSetup {
     function setUp() public {
         // Setup
         setUpSystemContracts();
+
+        recipient = payable(address(rfq));
 
         marketMakerProxy = new MarketMakerProxy(maker, maker, IWETH(address(weth)));
 


### PR DESCRIPTION
After discussion, the `feeColeector` of RFQv2 should be itself until the whole buyback design is updated. So the fee transfer can be skip if `to` is itself.