### PR TITLE
Refactor token collector

### DIFF
--- a/.github/workflows/gas-diff.yml
+++ b/.github/workflows/gas-diff.yml
@@ -4,12 +4,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    paths:
-      - contracts/**
-      - test/**
-      - foundry.toml
-      - remappings.txt
-      - .github/workflows/gas-diff.yml
 
 permissions:
   pull-requests: write
@@ -53,14 +47,14 @@ jobs:
           cat gasreport-fork.ansi >> $GITHUB_STEP_SUMMARY
 
       - name: Compare gas reports of local tests
-        uses: Rubilmax/foundry-gas-diff@v3.13.3
+        uses: Rubilmax/foundry-gas-diff@v3.14
         with:
           report: gasreport-local.ansi
           ignore: test/**/*
         id: gas_diff_local
 
       - name: Compare gas reports of fork tests
-        uses: Rubilmax/foundry-gas-diff@v3.13.3
+        uses: Rubilmax/foundry-gas-diff@v3.14
         with:
           report: gasreport-fork.ansi
           ignore: test/**/*

--- a/test/forkMainnet/GenericSwap.t.sol
+++ b/test/forkMainnet/GenericSwap.t.sol
@@ -61,7 +61,7 @@ contract GenericSwapTest is Test, Tokens, BalanceUtil {
         defaultPath[1] = DAI_ADDRESS;
         bytes memory makerSpecificData = abi.encode(defaultExpiry, defaultPath);
         bytes memory swapData = abi.encode(UNISWAP_V2_ADDRESS, makerSpecificData);
-        defaultTakerPermit = abi.encode(TokenCollector.Source.Token, bytes(""));
+        defaultTakerPermit = abi.encodePacked(TokenCollector.Source.Token);
 
         deal(taker, 100 ether);
         setTokenBalanceAndApprove(taker, address(genericSwap), tokens, 100000);

--- a/test/forkMainnet/LimitOrderSwap/Setup.t.sol
+++ b/test/forkMainnet/LimitOrderSwap/Setup.t.sol
@@ -63,7 +63,7 @@ contract LimitOrderSwapTest is Test, Tokens, BalanceUtil {
         setTokenBalanceAndApprove(taker, address(limitOrderSwap), tokens, 100000);
         deal(address(mockLimitOrderTaker), 100 ether);
         setTokenBalanceAndApprove(address(mockLimitOrderTaker), address(limitOrderSwap), tokens, 100000);
-        defaultPermit = abi.encode(TokenCollector.Source.Token, bytes(""));
+        defaultPermit = abi.encodePacked(TokenCollector.Source.Token);
 
         address[] memory tokenList = new address[](2);
         tokenList[0] = DAI_ADDRESS;

--- a/test/forkMainnet/RFQ.t.sol
+++ b/test/forkMainnet/RFQ.t.sol
@@ -73,7 +73,7 @@ contract RFQTest is Test, Tokens, BalanceUtil {
         setTokenBalanceAndApprove(taker, address(rfq), tokens, 100000);
         deal(takerWalletContract, 100 ether);
         setTokenBalanceAndApprove(takerWalletContract, address(rfq), tokens, 100000);
-        defaultPermit = abi.encode(TokenCollector.Source.Token, bytes(""));
+        defaultPermit = abi.encodePacked(TokenCollector.Source.Token);
 
         defaultRFQOffer = RFQOffer({
             taker: taker,
@@ -161,7 +161,7 @@ contract RFQTest is Test, Tokens, BalanceUtil {
     function testFillRFQWithTakerApproveAllowanceTarget() public {
         setTokenBalanceAndApprove(taker, address(allowanceTarget), tokens, 100000);
 
-        bytes memory takerPermit = abi.encode(TokenCollector.Source.TokenlonAllowanceTarget, bytes(""));
+        bytes memory takerPermit = abi.encodePacked(TokenCollector.Source.TokenlonAllowanceTarget);
 
         vm.prank(defaultRFQOffer.taker, defaultRFQOffer.taker);
         rfq.fillRFQ(defaultRFQTx, defaultMakerSig, defaultPermit, takerPermit);

--- a/test/forkMainnet/TokenCollector.t.sol
+++ b/test/forkMainnet/TokenCollector.t.sol
@@ -120,10 +120,7 @@ contract TestTokenCollector is Addresses {
         bytes32 r,
         bytes32 s
     ) private pure returns (bytes memory) {
-        return
-            bytes.concat(
-                abi.encodePacked(TokenCollector.Source.TokenPermit, abi.encode(permit.owner, permit.spender, permit.amount, permit.deadline, v, r, s))
-            );
+        return abi.encodePacked(TokenCollector.Source.TokenPermit, abi.encode(permit.owner, permit.spender, permit.amount, permit.deadline, v, r, s));
     }
 
     function testCannotCollectByTokenPermitWhenPermitSigIsInvalid() public {
@@ -235,10 +232,7 @@ contract TestTokenCollector is Addresses {
     }
 
     function encodePermit2Data(IUniswapPermit2.PermitSingle memory permit, bytes memory permitSig) private pure returns (bytes memory) {
-        return
-            bytes.concat(
-                abi.encodePacked(TokenCollector.Source.Permit2AllowanceTransfer, abi.encode(permit.details.nonce, permit.details.expiration, permitSig))
-            );
+        return abi.encodePacked(TokenCollector.Source.Permit2AllowanceTransfer, abi.encode(permit.details.nonce, permit.details.expiration, permitSig));
     }
 
     function testCannotCollectByPermit2AllowanceTransferWhenPermitSigIsInvalid() public {
@@ -357,7 +351,7 @@ contract TestTokenCollector is Addresses {
     }
 
     function encodePermit2Data(IUniswapPermit2.PermitTransferFrom memory permit, bytes memory permitSig) private pure returns (bytes memory) {
-        return bytes.concat(abi.encodePacked(TokenCollector.Source.Permit2SignatureTransfer, abi.encode(permit.nonce, permit.deadline, permitSig)));
+        return abi.encodePacked(TokenCollector.Source.Permit2SignatureTransfer, abi.encode(permit.nonce, permit.deadline, permitSig));
     }
 
     function testCannotCollectByPermit2SignatureTransferWhenSpenderIsInvalid() public {

--- a/test/forkMainnet/TokenCollector.t.sol
+++ b/test/forkMainnet/TokenCollector.t.sol
@@ -15,7 +15,7 @@ contract Strategy is TokenCollector {
         address from,
         address to,
         uint256 amount,
-        bytes memory data
+        bytes calldata data
     ) external {
         _collect(token, from, to, amount, data);
     }
@@ -120,7 +120,11 @@ contract TestTokenCollector is Addresses {
         bytes32 r,
         bytes32 s
     ) private pure returns (bytes memory) {
-        return abi.encode(TokenCollector.Source.TokenPermit, abi.encode(permit.owner, permit.spender, permit.amount, permit.deadline, v, r, s));
+        return
+            bytes.concat(
+                abi.encodePacked(TokenCollector.Source.TokenPermit),
+                abi.encode(permit.owner, permit.spender, permit.amount, permit.deadline, v, r, s)
+            );
     }
 
     function testCannotCollectByTokenPermitWhenPermitSigIsInvalid() public {
@@ -232,7 +236,11 @@ contract TestTokenCollector is Addresses {
     }
 
     function encodePermit2Data(IUniswapPermit2.PermitSingle memory permit, bytes memory permitSig) private pure returns (bytes memory) {
-        return abi.encode(TokenCollector.Source.Permit2AllowanceTransfer, abi.encode(permit.details.nonce, permit.details.expiration, permitSig));
+        return
+            bytes.concat(
+                abi.encodePacked(TokenCollector.Source.Permit2AllowanceTransfer),
+                abi.encode(permit.details.nonce, permit.details.expiration, permitSig)
+            );
     }
 
     function testCannotCollectByPermit2AllowanceTransferWhenPermitSigIsInvalid() public {
@@ -351,7 +359,7 @@ contract TestTokenCollector is Addresses {
     }
 
     function encodePermit2Data(IUniswapPermit2.PermitTransferFrom memory permit, bytes memory permitSig) private pure returns (bytes memory) {
-        return abi.encode(TokenCollector.Source.Permit2SignatureTransfer, abi.encode(permit.nonce, permit.deadline, permitSig));
+        return bytes.concat(abi.encodePacked(TokenCollector.Source.Permit2SignatureTransfer), abi.encode(permit.nonce, permit.deadline, permitSig));
     }
 
     function testCannotCollectByPermit2SignatureTransferWhenSpenderIsInvalid() public {

--- a/test/forkMainnet/TokenCollector.t.sol
+++ b/test/forkMainnet/TokenCollector.t.sol
@@ -122,8 +122,7 @@ contract TestTokenCollector is Addresses {
     ) private pure returns (bytes memory) {
         return
             bytes.concat(
-                abi.encodePacked(TokenCollector.Source.TokenPermit),
-                abi.encode(permit.owner, permit.spender, permit.amount, permit.deadline, v, r, s)
+                abi.encodePacked(TokenCollector.Source.TokenPermit, abi.encode(permit.owner, permit.spender, permit.amount, permit.deadline, v, r, s))
             );
     }
 
@@ -238,8 +237,7 @@ contract TestTokenCollector is Addresses {
     function encodePermit2Data(IUniswapPermit2.PermitSingle memory permit, bytes memory permitSig) private pure returns (bytes memory) {
         return
             bytes.concat(
-                abi.encodePacked(TokenCollector.Source.Permit2AllowanceTransfer),
-                abi.encode(permit.details.nonce, permit.details.expiration, permitSig)
+                abi.encodePacked(TokenCollector.Source.Permit2AllowanceTransfer, abi.encode(permit.details.nonce, permit.details.expiration, permitSig))
             );
     }
 
@@ -359,7 +357,7 @@ contract TestTokenCollector is Addresses {
     }
 
     function encodePermit2Data(IUniswapPermit2.PermitTransferFrom memory permit, bytes memory permitSig) private pure returns (bytes memory) {
-        return bytes.concat(abi.encodePacked(TokenCollector.Source.Permit2SignatureTransfer), abi.encode(permit.nonce, permit.deadline, permitSig));
+        return bytes.concat(abi.encodePacked(TokenCollector.Source.Permit2SignatureTransfer, abi.encode(permit.nonce, permit.deadline, permitSig)));
     }
 
     function testCannotCollectByPermit2SignatureTransferWhenSpenderIsInvalid() public {

--- a/test/forkMainnet/TokenCollector.t.sol
+++ b/test/forkMainnet/TokenCollector.t.sol
@@ -46,7 +46,7 @@ contract TestTokenCollector is Addresses {
     /* Token Approval */
 
     function testCannotCollectByTokenApprovalWhenAllowanceIsNotEnough() public {
-        bytes memory data = abi.encode(TokenCollector.Source.Token, bytes(""));
+        bytes memory data = abi.encodePacked(TokenCollector.Source.Token);
 
         vm.expectRevert("ERC20: insufficient allowance");
         strategy.collect(address(token), user, address(this), 1, data);
@@ -58,7 +58,7 @@ contract TestTokenCollector is Addresses {
         vm.prank(user);
         token.approve(address(strategy), amount);
 
-        bytes memory data = abi.encode(TokenCollector.Source.Token, bytes(""));
+        bytes memory data = abi.encodePacked(TokenCollector.Source.Token);
         strategy.collect(address(token), user, address(this), amount, data);
 
         uint256 balance = token.balanceOf(address(this));
@@ -66,7 +66,7 @@ contract TestTokenCollector is Addresses {
     }
 
     function testCannotCollectByAllowanceTargetIfNoPriorApprove() public {
-        bytes memory data = abi.encode(TokenCollector.Source.TokenlonAllowanceTarget, bytes(""));
+        bytes memory data = abi.encodePacked(TokenCollector.Source.TokenlonAllowanceTarget);
 
         vm.expectRevert("ERC20: insufficient allowance");
         strategy.collect(address(token), user, address(this), 1, data);
@@ -78,7 +78,7 @@ contract TestTokenCollector is Addresses {
         vm.prank(user);
         token.approve(address(allowanceTarget), amount);
 
-        bytes memory data = abi.encode(TokenCollector.Source.TokenlonAllowanceTarget, bytes(""));
+        bytes memory data = abi.encodePacked(TokenCollector.Source.TokenlonAllowanceTarget);
         strategy.collect(address(token), user, address(this), amount, data);
 
         uint256 balance = token.balanceOf(address(this));
@@ -120,7 +120,7 @@ contract TestTokenCollector is Addresses {
         bytes32 r,
         bytes32 s
     ) private pure returns (bytes memory) {
-        return abi.encode(TokenCollector.Source.Token, abi.encode(permit.owner, permit.spender, permit.amount, permit.deadline, v, r, s));
+        return abi.encode(TokenCollector.Source.TokenPermit, abi.encode(permit.owner, permit.spender, permit.amount, permit.deadline, v, r, s));
     }
 
     function testCannotCollectByTokenPermitWhenPermitSigIsInvalid() public {

--- a/test/forkMainnet/UniAgent/Setup.t.sol
+++ b/test/forkMainnet/UniAgent/Setup.t.sol
@@ -43,6 +43,6 @@ contract UniAgentTest is Test, Tokens, BalanceUtil {
         deal(user, 100 ether);
         setTokenBalanceAndApprove(user, address(uniAgent), tokens, 100000);
 
-        defaultUserPermit = abi.encode(TokenCollector.Source.Token, bytes(""));
+        defaultUserPermit = abi.encodePacked(TokenCollector.Source.Token);
     }
 }


### PR DESCRIPTION
~To shorten the data for token collector, add `length == 1` condition for basic token source type.~
Use bytes concat for permit data wrapping. First it's easier to detect the type of source without abi decoding, and second it saves some length of data.