### PR TITLE
fix token collector permit2 logic and test

### DIFF
--- a/contracts/abstracts/TokenCollector.sol
+++ b/contracts/abstracts/TokenCollector.sol
@@ -11,7 +11,6 @@ import { IAllowanceTarget } from "../interfaces/IAllowanceTarget.sol";
 abstract contract TokenCollector {
     using SafeERC20 for IERC20;
 
-    error Permit2AmountTooLarge();
     error Permit2DataEmpty();
 
     enum Source {
@@ -53,12 +52,11 @@ abstract contract TokenCollector {
             }
             return IERC20(token).safeTransferFrom(from, to, amount);
         } else if (src == Source.Permit2AllowanceTransfer) {
-            if (amount > uint256(type(uint160).max)) revert Permit2AmountTooLarge();
             bytes memory permit2Data = data[1:];
             if (permit2Data.length > 0) {
                 (uint48 nonce, uint48 deadline, bytes memory permitSig) = abi.decode(permit2Data, (uint48, uint48, bytes));
                 IUniswapPermit2.PermitSingle memory permit = IUniswapPermit2.PermitSingle({
-                    details: IUniswapPermit2.PermitDetails({ token: token, amount: uint160(amount), expiration: deadline, nonce: nonce }),
+                    details: IUniswapPermit2.PermitDetails({ token: token, amount: type(uint160).max, expiration: deadline, nonce: nonce }),
                     spender: address(this),
                     sigDeadline: uint256(deadline)
                 });

--- a/contracts/interfaces/IUniswapPermit2.sol
+++ b/contracts/interfaces/IUniswapPermit2.sol
@@ -54,6 +54,22 @@ interface IUniswapPermit2 {
     /// @dev Uses cached version if chainid and address are unchanged from construction.
     function DOMAIN_SEPARATOR() external view returns (bytes32);
 
+    /// @notice A mapping from owner address to token address to spender address to PackedAllowance struct, which contains details and conditions of the approval.
+    /// @notice The mapping is indexed in the above order see: allowance[ownerAddress][tokenAddress][spenderAddress]
+    /// @dev The packed slot holds the allowed amount, expiration at which the allowed amount is no longer valid, and current nonce thats updated on any signature based approvals.
+    function allowance(
+        address user,
+        address token,
+        address spender
+    )
+        external
+        view
+        returns (
+            uint160 amount,
+            uint48 expiration,
+            uint48 nonce
+        );
+
     /// @notice Permit a spender to a given amount of the owners token via the owner's EIP-712 signature
     /// @dev May fail if the owner's nonce was invalidated in-flight by invalidateNonce
     /// @param owner The owner of the tokens being approved

--- a/test/forkMainnet/GenericSwap.t.sol
+++ b/test/forkMainnet/GenericSwap.t.sol
@@ -7,6 +7,7 @@ import { BalanceUtil } from "test/utils/BalanceUtil.sol";
 import { getEIP712Hash } from "test/utils/Sig.sol";
 import { BalanceSnapshot, Snapshot } from "test/utils/BalanceSnapshot.sol";
 import { computeContractAddress } from "test/utils/Addresses.sol";
+import { Permit2Helper } from "test/utils/Permit2Helper.sol";
 import { MockStrategy } from "test/mocks/MockStrategy.sol";
 import { GenericSwap } from "contracts/GenericSwap.sol";
 import { AllowanceTarget } from "contracts/AllowanceTarget.sol";
@@ -17,7 +18,7 @@ import { GenericSwapData, getGSDataHash } from "contracts/libraries/GenericSwapD
 import { IGenericSwap } from "contracts/interfaces/IGenericSwap.sol";
 import { IUniswapRouterV2 } from "contracts/interfaces/IUniswapRouterV2.sol";
 
-contract GenericSwapTest is Test, Tokens, BalanceUtil {
+contract GenericSwapTest is Test, Tokens, BalanceUtil, Permit2Helper {
     using BalanceSnapshot for Snapshot;
 
     event Swap(
@@ -62,12 +63,11 @@ contract GenericSwapTest is Test, Tokens, BalanceUtil {
         defaultPath[1] = DAI_ADDRESS;
         bytes memory makerSpecificData = abi.encode(defaultExpiry, defaultPath);
         bytes memory swapData = abi.encode(UNISWAP_V2_ADDRESS, makerSpecificData);
-        defaultTakerPermit = abi.encodePacked(TokenCollector.Source.Token);
 
         deal(taker, 100 ether);
-        setTokenBalanceAndApprove(taker, address(genericSwap), tokens, 100000);
+        setTokenBalanceAndApprove(taker, UNISWAP_PERMIT2_ADDRESS, tokens, 100000);
         deal(address(mockStrategy), 100 ether);
-        setTokenBalanceAndApprove(address(mockStrategy), address(genericSwap), tokens, 100000);
+        setTokenBalanceAndApprove(address(mockStrategy), UNISWAP_PERMIT2_ADDRESS, tokens, 100000);
 
         defaultGSData = GenericSwapData({
             maker: payable(address(uniswapStrategy)),
@@ -81,6 +81,8 @@ contract GenericSwapTest is Test, Tokens, BalanceUtil {
             recipient: payable(taker),
             strategyData: swapData
         });
+
+        defaultTakerPermit = getTokenlonPermit2Data(takerPrivateKey, defaultGSData.takerToken, address(genericSwap));
 
         IUniswapRouterV2 router = IUniswapRouterV2(UNISWAP_V2_ADDRESS);
         uint256[] memory amounts = router.getAmountsOut(defaultGSData.takerTokenAmount, defaultPath);

--- a/test/forkMainnet/GenericSwap.t.sol
+++ b/test/forkMainnet/GenericSwap.t.sol
@@ -82,7 +82,7 @@ contract GenericSwapTest is Test, Tokens, BalanceUtil, Permit2Helper {
             strategyData: swapData
         });
 
-        defaultTakerPermit = getTokenlonPermit2Data(takerPrivateKey, defaultGSData.takerToken, address(genericSwap));
+        defaultTakerPermit = getTokenlonPermit2Data(taker, takerPrivateKey, defaultGSData.takerToken, address(genericSwap));
 
         IUniswapRouterV2 router = IUniswapRouterV2(UNISWAP_V2_ADDRESS);
         uint256[] memory amounts = router.getAmountsOut(defaultGSData.takerTokenAmount, defaultPath);

--- a/test/forkMainnet/LimitOrderSwap/CoordinatedTaker.t.sol
+++ b/test/forkMainnet/LimitOrderSwap/CoordinatedTaker.t.sol
@@ -58,7 +58,7 @@ contract CoordinatedTakerTest is LimitOrderSwapTest {
 
         defaultMakerSig = _signLimitOrder(makerPrivateKey, defaultCrdOrder);
 
-        defaultUserPrmit = getTokenlonPermit2Data(userPrivateKey, defaultCrdOrder.takerToken, address(coordinatedTaker));
+        defaultUserPrmit = getTokenlonPermit2Data(user, userPrivateKey, defaultCrdOrder.takerToken, address(coordinatedTaker));
 
         defaultAllowFill = AllowFill({
             orderHash: getLimitOrderHash(defaultCrdOrder),

--- a/test/forkMainnet/LimitOrderSwap/CoordinatedTaker.t.sol
+++ b/test/forkMainnet/LimitOrderSwap/CoordinatedTaker.t.sol
@@ -20,13 +20,15 @@ contract CoordinatedTakerTest is LimitOrderSwapTest {
     event SetCoordinator(address newCoordinator);
 
     address crdTakerOwner = makeAddr("crdTakerOwner");
-    address user = makeAddr("user");
+    uint256 userPrivateKey = uint256(5);
+    address user = vm.addr(userPrivateKey);
 
     address[] tokenList = [USDC_ADDRESS, USDT_ADDRESS, DAI_ADDRESS, WETH_ADDRESS, WBTC_ADDRESS];
     address[] ammList = [UNISWAP_V2_ADDRESS, SUSHISWAP_ADDRESS, BALANCER_V2_ADDRESS, CURVE_USDT_POOL_ADDRESS];
 
     uint256 crdPrivateKey = uint256(2);
     address coordinator = vm.addr(crdPrivateKey);
+    bytes defaultUserPrmit;
     LimitOrder defaultCrdOrder;
     AllowFill defaultAllowFill;
     ICoordinatedTaker.CoordinatorParams defaultCRDParams;
@@ -49,12 +51,14 @@ contract CoordinatedTakerTest is LimitOrderSwapTest {
         coordinatedTaker.approveTokens(tokenList, targetList);
 
         deal(user, 100 ether);
-        setTokenBalanceAndApprove(user, address(coordinatedTaker), tokens, 100000);
+        setTokenBalanceAndApprove(user, UNISWAP_PERMIT2_ADDRESS, tokens, 100000);
 
         defaultCrdOrder = defaultOrder;
         defaultCrdOrder.taker = address(coordinatedTaker);
 
         defaultMakerSig = _signLimitOrder(makerPrivateKey, defaultCrdOrder);
+
+        defaultUserPrmit = getTokenlonPermit2Data(userPrivateKey, defaultCrdOrder.takerToken, address(coordinatedTaker));
 
         defaultAllowFill = AllowFill({
             orderHash: getLimitOrderHash(defaultCrdOrder),
@@ -163,7 +167,7 @@ contract CoordinatedTakerTest is LimitOrderSwapTest {
             takerTokenAmount: defaultCrdOrder.takerTokenAmount,
             makerTokenAmount: defaultCrdOrder.makerTokenAmount,
             extraAction: bytes(""),
-            userTokenPermit: defaultPermit,
+            userTokenPermit: defaultUserPrmit,
             crdParams: defaultCRDParams
         });
 
@@ -224,7 +228,7 @@ contract CoordinatedTakerTest is LimitOrderSwapTest {
             takerTokenAmount: order.takerTokenAmount,
             makerTokenAmount: order.makerTokenAmount,
             extraAction: bytes(""),
-            userTokenPermit: defaultPermit,
+            userTokenPermit: defaultUserPrmit,
             crdParams: crdParams
         });
 
@@ -246,7 +250,7 @@ contract CoordinatedTakerTest is LimitOrderSwapTest {
             takerTokenAmount: defaultCrdOrder.takerTokenAmount,
             makerTokenAmount: defaultCrdOrder.makerTokenAmount,
             extraAction: bytes(""),
-            userTokenPermit: defaultPermit,
+            userTokenPermit: defaultUserPrmit,
             crdParams: defaultCRDParams
         });
     }
@@ -266,7 +270,7 @@ contract CoordinatedTakerTest is LimitOrderSwapTest {
             takerTokenAmount: defaultCrdOrder.takerTokenAmount,
             makerTokenAmount: defaultCrdOrder.makerTokenAmount,
             extraAction: bytes(""),
-            userTokenPermit: defaultPermit,
+            userTokenPermit: defaultUserPrmit,
             crdParams: crdParams
         });
     }
@@ -279,7 +283,7 @@ contract CoordinatedTakerTest is LimitOrderSwapTest {
             takerTokenAmount: defaultCrdOrder.takerTokenAmount,
             makerTokenAmount: defaultCrdOrder.makerTokenAmount,
             extraAction: bytes(""),
-            userTokenPermit: defaultPermit,
+            userTokenPermit: defaultUserPrmit,
             crdParams: defaultCRDParams
         });
 
@@ -291,7 +295,7 @@ contract CoordinatedTakerTest is LimitOrderSwapTest {
             takerTokenAmount: defaultCrdOrder.takerTokenAmount,
             makerTokenAmount: defaultCrdOrder.makerTokenAmount,
             extraAction: bytes(""),
-            userTokenPermit: defaultPermit,
+            userTokenPermit: allowanceTransferPermit, // should be able to transfer without permit data
             crdParams: defaultCRDParams
         });
     }
@@ -305,7 +309,7 @@ contract CoordinatedTakerTest is LimitOrderSwapTest {
             takerTokenAmount: defaultCrdOrder.takerTokenAmount,
             makerTokenAmount: defaultCrdOrder.makerTokenAmount,
             extraAction: bytes(""),
-            userTokenPermit: defaultPermit,
+            userTokenPermit: defaultUserPrmit,
             crdParams: defaultCRDParams
         });
     }

--- a/test/forkMainnet/LimitOrderSwap/CoordinatedTaker.t.sol
+++ b/test/forkMainnet/LimitOrderSwap/CoordinatedTaker.t.sol
@@ -306,7 +306,7 @@ contract CoordinatedTakerTest is LimitOrderSwapTest {
             takerTokenAmount: defaultCrdOrder.takerTokenAmount,
             makerTokenAmount: defaultCrdOrder.makerTokenAmount,
             extraAction: bytes(""),
-            userTokenPermit: allowanceTransferPermit, // should be able to transfer without permit data
+            userTokenPermit: allowanceTransferPermit, // should transfer from permit2 allowance directly
             crdParams: defaultCRDParams
         });
     }

--- a/test/forkMainnet/LimitOrderSwap/Fill.t.sol
+++ b/test/forkMainnet/LimitOrderSwap/Fill.t.sol
@@ -110,7 +110,7 @@ contract FillTest is LimitOrderSwapTest {
                 makerTokenAmount: order.makerTokenAmount,
                 recipient: address(mockLimitOrderTaker),
                 extraAction: extraAction,
-                takerTokenPermit: defaultPermit
+                takerTokenPermit: directApprovePermit
             })
         });
 
@@ -203,7 +203,7 @@ contract FillTest is LimitOrderSwapTest {
                 makerTokenAmount: order.makerTokenAmount,
                 recipient: recipient,
                 extraAction: bytes(""),
-                takerTokenPermit: defaultPermit
+                takerTokenPermit: defaultTakerPermit
             })
         });
 
@@ -293,7 +293,7 @@ contract FillTest is LimitOrderSwapTest {
                 makerTokenAmount: traderMakingAmount,
                 recipient: recipient,
                 extraAction: bytes(""),
-                takerTokenPermit: defaultPermit
+                takerTokenPermit: defaultTakerPermit
             })
         });
 
@@ -376,7 +376,7 @@ contract FillTest is LimitOrderSwapTest {
             takerTokenAmount: 1 ether,
             makerToken: DAI_ADDRESS,
             makerTokenAmount: 1000 ether,
-            makerTokenPermit: defaultPermit,
+            makerTokenPermit: defaultMakerPermit,
             feeFactor: defaultFeeFactor,
             expiry: defaultExpiry,
             salt: defaultSalt
@@ -411,7 +411,7 @@ contract FillTest is LimitOrderSwapTest {
                 makerTokenAmount: traderMakingAmount,
                 recipient: recipient,
                 extraAction: bytes(""),
-                takerTokenPermit: defaultPermit
+                takerTokenPermit: defaultTakerPermit
             })
         });
 
@@ -435,7 +435,7 @@ contract FillTest is LimitOrderSwapTest {
                 makerTokenAmount: defaultOrder.makerTokenAmount / 10,
                 recipient: recipient,
                 extraAction: bytes(""),
-                takerTokenPermit: defaultPermit
+                takerTokenPermit: defaultTakerPermit
             })
         });
 
@@ -449,7 +449,7 @@ contract FillTest is LimitOrderSwapTest {
                 makerTokenAmount: defaultOrder.makerTokenAmount / 10,
                 recipient: recipient,
                 extraAction: bytes(""),
-                takerTokenPermit: defaultPermit
+                takerTokenPermit: allowanceTransferPermit
             })
         });
     }
@@ -486,7 +486,7 @@ contract FillTest is LimitOrderSwapTest {
                 makerTokenAmount: defaultOrder.makerTokenAmount,
                 recipient: randomTaker,
                 extraAction: extraAction,
-                takerTokenPermit: defaultPermit
+                takerTokenPermit: directApprovePermit
             })
         });
         vm.stopPrank();

--- a/test/forkMainnet/LimitOrderSwap/FullOrKill.t.sol
+++ b/test/forkMainnet/LimitOrderSwap/FullOrKill.t.sol
@@ -46,7 +46,7 @@ contract FullOrKillTest is LimitOrderSwapTest {
                 makerTokenAmount: traderMakingAmount,
                 recipient: recipient,
                 extraAction: bytes(""),
-                takerTokenPermit: defaultPermit
+                takerTokenPermit: defaultTakerPermit
             })
         });
 
@@ -74,7 +74,7 @@ contract FullOrKillTest is LimitOrderSwapTest {
                 makerTokenAmount: traderMakingAmount,
                 recipient: recipient,
                 extraAction: bytes(""),
-                takerTokenPermit: defaultPermit
+                takerTokenPermit: defaultTakerPermit
             })
         });
     }
@@ -94,7 +94,7 @@ contract FullOrKillTest is LimitOrderSwapTest {
                 makerTokenAmount: traderMakingAmount,
                 recipient: recipient,
                 extraAction: bytes(""),
-                takerTokenPermit: defaultPermit
+                takerTokenPermit: defaultTakerPermit
             })
         });
     }

--- a/test/forkMainnet/LimitOrderSwap/GroupFill.t.sol
+++ b/test/forkMainnet/LimitOrderSwap/GroupFill.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.17;
 
 import { ILimitOrderSwap } from "contracts/interfaces/ILimitOrderSwap.sol";
+import { IUniswapPermit2 } from "contracts/interfaces/IUniswapPermit2.sol";
 import { LimitOrder, getLimitOrderHash } from "contracts/libraries/LimitOrder.sol";
 import { Constant } from "contracts/libraries/Constant.sol";
 import { BalanceSnapshot, Snapshot } from "test/utils/BalanceSnapshot.sol";
@@ -21,7 +22,19 @@ contract GroupFillTest is LimitOrderSwapTest {
         for (uint256 i = 0; i < makerPrivateKeys.length; ++i) {
             makers[i] = payable(vm.addr(makerPrivateKeys[i]));
             deal(makers[i], 100 ether);
-            setTokenBalanceAndApprove(makers[i], address(limitOrderSwap), tokens, 100000);
+            setTokenBalanceAndApprove(makers[i], UNISWAP_PERMIT2_ADDRESS, tokens, 100000);
+
+            vm.startPrank(makers[i]);
+            for (uint256 j = 0; j < tokens.length; ++j) {
+                // maker should call permit2 first independently
+                IUniswapPermit2(UNISWAP_PERMIT2_ADDRESS).approve(
+                    address(tokens[j]),
+                    address(limitOrderSwap),
+                    type(uint160).max,
+                    uint48(block.timestamp + 1 days)
+                );
+            }
+            vm.stopPrank();
         }
     }
 
@@ -38,7 +51,7 @@ contract GroupFillTest is LimitOrderSwapTest {
             takerTokenAmount: 10 * 1e6,
             makerToken: DAI_ADDRESS,
             makerTokenAmount: 10 ether,
-            makerTokenPermit: defaultPermit,
+            makerTokenPermit: defaultMakerPermit,
             feeFactor: 0,
             expiry: defaultExpiry,
             salt: defaultSalt
@@ -56,7 +69,7 @@ contract GroupFillTest is LimitOrderSwapTest {
             takerTokenAmount: 8 ether,
             makerToken: USDT_ADDRESS,
             makerTokenAmount: 10 * 1e6,
-            makerTokenPermit: defaultPermit,
+            makerTokenPermit: defaultMakerPermit,
             feeFactor: 0,
             expiry: defaultExpiry,
             salt: defaultSalt
@@ -95,7 +108,7 @@ contract GroupFillTest is LimitOrderSwapTest {
             takerTokenAmount: 10 * 1e6,
             makerToken: DAI_ADDRESS,
             makerTokenAmount: 10 ether,
-            makerTokenPermit: defaultPermit,
+            makerTokenPermit: defaultMakerPermit,
             feeFactor: 0,
             expiry: defaultExpiry,
             salt: defaultSalt
@@ -113,7 +126,7 @@ contract GroupFillTest is LimitOrderSwapTest {
             takerTokenAmount: 35 * 1e6,
             makerToken: DAI_ADDRESS,
             makerTokenAmount: 35 ether,
-            makerTokenPermit: defaultPermit,
+            makerTokenPermit: defaultMakerPermit,
             feeFactor: 0,
             expiry: defaultExpiry,
             salt: defaultSalt
@@ -131,7 +144,7 @@ contract GroupFillTest is LimitOrderSwapTest {
             takerTokenAmount: 1000 ether,
             makerToken: USDT_ADDRESS,
             makerTokenAmount: 1000 * 1e6,
-            makerTokenPermit: defaultPermit,
+            makerTokenPermit: defaultMakerPermit,
             feeFactor: 0,
             expiry: defaultExpiry,
             salt: defaultSalt
@@ -169,7 +182,7 @@ contract GroupFillTest is LimitOrderSwapTest {
             takerTokenAmount: 2000 * 1e6,
             makerToken: WETH_ADDRESS,
             makerTokenAmount: 1 ether,
-            makerTokenPermit: defaultPermit,
+            makerTokenPermit: defaultMakerPermit,
             feeFactor: 0,
             expiry: defaultExpiry,
             salt: defaultSalt
@@ -187,7 +200,7 @@ contract GroupFillTest is LimitOrderSwapTest {
             takerTokenAmount: 1 ether,
             makerToken: USDT_ADDRESS,
             makerTokenAmount: 2000 * 1e6,
-            makerTokenPermit: defaultPermit,
+            makerTokenPermit: defaultMakerPermit,
             feeFactor: 0,
             expiry: defaultExpiry,
             salt: defaultSalt
@@ -226,7 +239,7 @@ contract GroupFillTest is LimitOrderSwapTest {
             takerTokenAmount: 8000 * 1e6,
             makerToken: WETH_ADDRESS,
             makerTokenAmount: 5 ether,
-            makerTokenPermit: defaultPermit,
+            makerTokenPermit: defaultMakerPermit,
             feeFactor: 0,
             expiry: defaultExpiry,
             salt: defaultSalt
@@ -244,7 +257,7 @@ contract GroupFillTest is LimitOrderSwapTest {
             takerTokenAmount: 1 ether,
             makerToken: USDT_ADDRESS,
             makerTokenAmount: 2000 * 1e6,
-            makerTokenPermit: defaultPermit,
+            makerTokenPermit: defaultMakerPermit,
             feeFactor: 0,
             expiry: defaultExpiry,
             salt: defaultSalt
@@ -262,7 +275,7 @@ contract GroupFillTest is LimitOrderSwapTest {
             takerTokenAmount: 3 ether,
             makerToken: USDT_ADDRESS,
             makerTokenAmount: 6000 * 1e6,
-            makerTokenPermit: defaultPermit,
+            makerTokenPermit: defaultMakerPermit,
             feeFactor: 0,
             expiry: defaultExpiry,
             salt: defaultSalt
@@ -308,7 +321,7 @@ contract GroupFillTest is LimitOrderSwapTest {
             takerTokenAmount: 2000 * 1e6,
             makerToken: WETH_ADDRESS,
             makerTokenAmount: 1 ether,
-            makerTokenPermit: defaultPermit,
+            makerTokenPermit: defaultMakerPermit,
             feeFactor: 0,
             expiry: defaultExpiry,
             salt: defaultSalt
@@ -326,7 +339,7 @@ contract GroupFillTest is LimitOrderSwapTest {
             takerTokenAmount: 1.5 ether,
             makerToken: USDT_ADDRESS,
             makerTokenAmount: 2000 * 1e6,
-            makerTokenPermit: defaultPermit,
+            makerTokenPermit: defaultMakerPermit,
             feeFactor: 0,
             expiry: defaultExpiry,
             salt: defaultSalt
@@ -368,7 +381,7 @@ contract GroupFillTest is LimitOrderSwapTest {
             takerTokenAmount: 10 * 1e6,
             makerToken: USDC_ADDRESS,
             makerTokenAmount: 10 * 1e6,
-            makerTokenPermit: defaultPermit,
+            makerTokenPermit: defaultMakerPermit,
             feeFactor: 0,
             expiry: defaultExpiry,
             salt: defaultSalt
@@ -386,7 +399,7 @@ contract GroupFillTest is LimitOrderSwapTest {
             takerTokenAmount: 10 ether,
             makerToken: USDT_ADDRESS,
             makerTokenAmount: 10 * 1e6,
-            makerTokenPermit: defaultPermit,
+            makerTokenPermit: defaultMakerPermit,
             feeFactor: 0,
             expiry: defaultExpiry,
             salt: defaultSalt
@@ -404,7 +417,7 @@ contract GroupFillTest is LimitOrderSwapTest {
             takerTokenAmount: 10 * 1e6,
             makerToken: DAI_ADDRESS,
             makerTokenAmount: 10 ether,
-            makerTokenPermit: defaultPermit,
+            makerTokenPermit: defaultMakerPermit,
             feeFactor: 0,
             expiry: defaultExpiry,
             salt: defaultSalt

--- a/test/forkMainnet/LimitOrderSwap/Setup.t.sol
+++ b/test/forkMainnet/LimitOrderSwap/Setup.t.sol
@@ -96,7 +96,7 @@ contract LimitOrderSwapTest is Test, Tokens, BalanceUtil, Permit2Helper {
         vm.prank(maker);
         IUniswapPermit2(UNISWAP_PERMIT2_ADDRESS).approve(defaultOrder.makerToken, address(limitOrderSwap), type(uint160).max, uint48(block.timestamp + 1 days));
 
-        defaultTakerPermit = getTokenlonPermit2Data(takerPrivateKey, defaultOrder.takerToken, address(limitOrderSwap));
+        defaultTakerPermit = getTokenlonPermit2Data(taker, takerPrivateKey, defaultOrder.takerToken, address(limitOrderSwap));
 
         defaultTakerParams = ILimitOrderSwap.TakerParams({
             takerTokenAmount: defaultOrder.takerTokenAmount,

--- a/test/forkMainnet/LimitOrderSwap/Setup.t.sol
+++ b/test/forkMainnet/LimitOrderSwap/Setup.t.sol
@@ -6,15 +6,17 @@ import { Tokens } from "test/utils/Tokens.sol";
 import { BalanceUtil } from "test/utils/BalanceUtil.sol";
 import { getEIP712Hash } from "test/utils/Sig.sol";
 import { computeContractAddress } from "test/utils/Addresses.sol";
+import { Permit2Helper } from "test/utils/Permit2Helper.sol";
 import { MockLimitOrderTaker } from "test/mocks/MockLimitOrderTaker.sol";
 import { LimitOrderSwap } from "contracts/LimitOrderSwap.sol";
 import { AllowanceTarget } from "contracts/AllowanceTarget.sol";
 import { IWETH } from "contracts/interfaces/IWETH.sol";
 import { ILimitOrderSwap } from "contracts/interfaces/ILimitOrderSwap.sol";
+import { IUniswapPermit2 } from "contracts/interfaces/IUniswapPermit2.sol";
 import { TokenCollector } from "contracts/abstracts/TokenCollector.sol";
 import { LimitOrder, getLimitOrderHash } from "contracts/libraries/LimitOrder.sol";
 
-contract LimitOrderSwapTest is Test, Tokens, BalanceUtil {
+contract LimitOrderSwapTest is Test, Tokens, BalanceUtil, Permit2Helper {
     event SetFeeCollector(address newFeeCollector);
     event LimitOrderFilled(
         bytes32 indexed offerHash,
@@ -32,7 +34,8 @@ contract LimitOrderSwapTest is Test, Tokens, BalanceUtil {
     address allowanceTargetOwner = makeAddr("allowanceTargetOwner");
     uint256 makerPrivateKey = uint256(1);
     address payable maker = payable(vm.addr(makerPrivateKey));
-    address taker = makeAddr("taker");
+    uint256 takerPrivateKey = uint256(2);
+    address taker = vm.addr(takerPrivateKey);
     address payable recipient = payable(makeAddr("recipient"));
     address payable feeCollector = payable(makeAddr("feeCollector"));
     address walletOwner = makeAddr("walletOwner");
@@ -41,7 +44,10 @@ contract LimitOrderSwapTest is Test, Tokens, BalanceUtil {
     uint256 defaultFeeFactor = 100;
     LimitOrder defaultOrder;
     bytes defaultMakerSig;
-    bytes defaultPermit;
+    bytes directApprovePermit = abi.encodePacked(TokenCollector.Source.Token);
+    bytes allowanceTransferPermit = abi.encodePacked(TokenCollector.Source.Permit2AllowanceTransfer);
+    bytes defaultMakerPermit = allowanceTransferPermit;
+    bytes defaultTakerPermit;
     ILimitOrderSwap.TakerParams defaultTakerParams;
     MockLimitOrderTaker mockLimitOrderTaker;
     LimitOrderSwap limitOrderSwap;
@@ -59,12 +65,12 @@ contract LimitOrderSwapTest is Test, Tokens, BalanceUtil {
         mockLimitOrderTaker = new MockLimitOrderTaker(walletOwner, UNISWAP_V2_ADDRESS);
 
         deal(maker, 100 ether);
-        setTokenBalanceAndApprove(maker, address(limitOrderSwap), tokens, 100000);
+        setTokenBalanceAndApprove(maker, UNISWAP_PERMIT2_ADDRESS, tokens, 100000);
         deal(taker, 100 ether);
-        setTokenBalanceAndApprove(taker, address(limitOrderSwap), tokens, 100000);
+        setTokenBalanceAndApprove(taker, UNISWAP_PERMIT2_ADDRESS, tokens, 100000);
         deal(address(mockLimitOrderTaker), 100 ether);
+        // mockLimitOrderTaker approve LO contract directly for convenience
         setTokenBalanceAndApprove(address(mockLimitOrderTaker), address(limitOrderSwap), tokens, 100000);
-        defaultPermit = abi.encodePacked(TokenCollector.Source.Token);
 
         address[] memory tokenList = new address[](2);
         tokenList[0] = DAI_ADDRESS;
@@ -80,18 +86,24 @@ contract LimitOrderSwapTest is Test, Tokens, BalanceUtil {
             takerTokenAmount: 10 * 1e6,
             makerToken: DAI_ADDRESS,
             makerTokenAmount: 10 ether,
-            makerTokenPermit: defaultPermit,
+            makerTokenPermit: defaultMakerPermit,
             feeFactor: defaultFeeFactor,
             expiry: defaultExpiry,
             salt: defaultSalt
         });
+
+        // maker should call permit2 first independently
+        vm.prank(maker);
+        IUniswapPermit2(UNISWAP_PERMIT2_ADDRESS).approve(defaultOrder.makerToken, address(limitOrderSwap), type(uint160).max, uint48(block.timestamp + 1 days));
+
+        defaultTakerPermit = getTokenlonPermit2Data(takerPrivateKey, defaultOrder.takerToken, address(limitOrderSwap));
 
         defaultTakerParams = ILimitOrderSwap.TakerParams({
             takerTokenAmount: defaultOrder.takerTokenAmount,
             makerTokenAmount: defaultOrder.makerTokenAmount,
             recipient: recipient,
             extraAction: bytes(""),
-            takerTokenPermit: defaultPermit
+            takerTokenPermit: defaultTakerPermit
         });
 
         defaultMakerSig = _signLimitOrder(makerPrivateKey, defaultOrder);

--- a/test/forkMainnet/RFQ.t.sol
+++ b/test/forkMainnet/RFQ.t.sol
@@ -13,6 +13,7 @@ import { RFQ } from "contracts/RFQ.sol";
 import { AllowanceTarget } from "contracts/AllowanceTarget.sol";
 import { IRFQ } from "contracts/interfaces/IRFQ.sol";
 import { IWETH } from "contracts/interfaces/IWETH.sol";
+import { IUniswapPermit2 } from "contracts/interfaces/IUniswapPermit2.sol";
 import { TokenCollector } from "contracts/abstracts/TokenCollector.sol";
 import { RFQOffer, getRFQOfferHash } from "contracts/libraries/RFQOffer.sol";
 import { RFQTx, getRFQTxHash } from "contracts/libraries/RFQTx.sol";
@@ -76,6 +77,8 @@ contract RFQTest is Test, Tokens, BalanceUtil, Permit2Helper {
         setTokenBalanceAndApprove(taker, UNISWAP_PERMIT2_ADDRESS, tokens, 100000);
         deal(takerWalletContract, 100 ether);
         setTokenBalanceAndApprove(takerWalletContract, UNISWAP_PERMIT2_ADDRESS, tokens, 100000);
+        vm.prank(takerWalletContract);
+        IUniswapPermit2(UNISWAP_PERMIT2_ADDRESS).approve(USDT_ADDRESS, address(rfq), type(uint160).max, uint48(block.timestamp + 1 days));
 
         defaultRFQOffer = RFQOffer({
             taker: taker,

--- a/test/forkMainnet/RFQ.t.sol
+++ b/test/forkMainnet/RFQ.t.sol
@@ -93,7 +93,7 @@ contract RFQTest is Test, Tokens, BalanceUtil, Permit2Helper {
 
         defaultMakerSig = _signRFQOffer(makerSignerPrivateKey, defaultRFQOffer);
 
-        defaultTakerPermit = getTokenlonPermit2Data(takerPrivateKey, defaultRFQOffer.takerToken, address(rfq));
+        defaultTakerPermit = getTokenlonPermit2Data(taker, takerPrivateKey, defaultRFQOffer.takerToken, address(rfq));
 
         vm.label(taker, "taker");
         vm.label(maker, "maker");
@@ -302,7 +302,7 @@ contract RFQTest is Test, Tokens, BalanceUtil, Permit2Helper {
         rfqTx.rfqOffer = rfqOffer;
         rfqTx.takerRequestAmount = rfqOffer.takerTokenAmount;
 
-        bytes memory takerPermit = getTokenlonPermit2Data(takerPrivateKey, rfqOffer.takerToken, address(rfq));
+        bytes memory takerPermit = getTokenlonPermit2Data(taker, takerPrivateKey, rfqOffer.takerToken, address(rfq));
 
         vm.prank(rfqOffer.taker, rfqOffer.taker);
         rfq.fillRFQ(rfqTx, makerSig, defaultMakerPermit, takerPermit);

--- a/test/forkMainnet/TokenCollector.t.sol
+++ b/test/forkMainnet/TokenCollector.t.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.17;
 
 import { AllowanceTarget } from "contracts/AllowanceTarget.sol";
 import { TokenCollector } from "contracts/abstracts/TokenCollector.sol";
-import { Constant } from "contracts/libraries/Constant.sol";
 import { IUniswapPermit2 } from "contracts/interfaces/IUniswapPermit2.sol";
 import { MockERC20Permit } from "test/mocks/MockERC20Permit.sol";
 import { Addresses, computeContractAddress } from "test/utils/Addresses.sol";
@@ -307,7 +306,7 @@ contract TestTokenCollector is Addresses {
         uint256 amount = 1234;
 
         vm.prank(user);
-        token.approve(address(permit2), Constant.MAX_UINT);
+        token.approve(address(permit2), type(uint256).max);
 
         bytes32 permitHash = getPermit2PermitHash(permit);
         bytes memory permitSig = signPermit2(userPrivateKey, permitHash);
@@ -326,7 +325,7 @@ contract TestTokenCollector is Addresses {
         uint256 amount = 1234;
 
         vm.prank(user);
-        token.approve(address(permit2), Constant.MAX_UINT);
+        token.approve(address(permit2), type(uint256).max);
 
         bytes32 permitHash = getPermit2PermitHash(permit);
         bytes memory permitSig = signPermit2(userPrivateKey, permitHash);

--- a/test/forkMainnet/UniAgent/Setup.t.sol
+++ b/test/forkMainnet/UniAgent/Setup.t.sol
@@ -7,6 +7,7 @@ import { BalanceUtil } from "test/utils/BalanceUtil.sol";
 import { getEIP712Hash } from "test/utils/Sig.sol";
 import { BalanceSnapshot, Snapshot } from "test/utils/BalanceSnapshot.sol";
 import { computeContractAddress } from "test/utils/Addresses.sol";
+import { Permit2Helper } from "test/utils/Permit2Helper.sol";
 import { UniAgent } from "contracts/UniAgent.sol";
 import { AllowanceTarget } from "contracts/AllowanceTarget.sol";
 import { TokenCollector } from "contracts/abstracts/TokenCollector.sol";
@@ -14,7 +15,7 @@ import { Constant } from "contracts/libraries/Constant.sol";
 import { IUniAgent } from "contracts/interfaces/IUniAgent.sol";
 import { IWETH } from "contracts/interfaces/IWETH.sol";
 
-contract UniAgentTest is Test, Tokens, BalanceUtil {
+contract UniAgentTest is Test, Tokens, BalanceUtil, Permit2Helper {
     uint256 userPrivateKey = uint256(1);
     address user = vm.addr(userPrivateKey);
     address uniAgentOwner = makeAddr("uniAgentOwner");
@@ -41,8 +42,8 @@ contract UniAgentTest is Test, Tokens, BalanceUtil {
         uniAgent.approveTokensToRouters(defaultPath);
 
         deal(user, 100 ether);
-        setTokenBalanceAndApprove(user, address(uniAgent), tokens, 100000);
+        setTokenBalanceAndApprove(user, UNISWAP_PERMIT2_ADDRESS, tokens, 100000);
 
-        defaultUserPermit = abi.encodePacked(TokenCollector.Source.Token);
+        defaultUserPermit = getTokenlonPermit2Data(userPrivateKey, defaultInputToken, address(uniAgent));
     }
 }

--- a/test/forkMainnet/UniAgent/Setup.t.sol
+++ b/test/forkMainnet/UniAgent/Setup.t.sol
@@ -44,6 +44,6 @@ contract UniAgentTest is Test, Tokens, BalanceUtil, Permit2Helper {
         deal(user, 100 ether);
         setTokenBalanceAndApprove(user, UNISWAP_PERMIT2_ADDRESS, tokens, 100000);
 
-        defaultUserPermit = getTokenlonPermit2Data(userPrivateKey, defaultInputToken, address(uniAgent));
+        defaultUserPermit = getTokenlonPermit2Data(user, userPrivateKey, defaultInputToken, address(uniAgent));
     }
 }

--- a/test/forkMainnet/UniAgent/V2.t.sol
+++ b/test/forkMainnet/UniAgent/V2.t.sol
@@ -103,7 +103,7 @@ contract V2Test is UniAgentTest {
         uint256 outputAmount = amounts[amounts.length - 1];
 
         bytes memory payload = abi.encodeCall(IUniswapRouterV2.swapExactTokensForTokens, (defaultInputAmount, outputAmount, path, recipient, defaultExpiry));
-        bytes memory userPermit = getTokenlonPermit2Data(userPrivateKey, inputToken, address(uniAgent));
+        bytes memory userPermit = getTokenlonPermit2Data(user, userPrivateKey, inputToken, address(uniAgent));
 
         vm.prank(user);
         uniAgent.approveAndSwap(IUniAgent.RouterType.V2Router, inputToken, defaultInputAmount, payload, userPermit);
@@ -134,7 +134,7 @@ contract V2Test is UniAgentTest {
         uint256 outputAmount = amounts[amounts.length - 1];
 
         bytes memory payload = abi.encodeCall(IUniswapRouterV2.swapExactTokensForTokens, (defaultInputAmount, outputAmount, path, recipient, defaultExpiry));
-        bytes memory userPermit = getTokenlonPermit2Data(userPrivateKey, inputToken, address(uniAgent));
+        bytes memory userPermit = getTokenlonPermit2Data(user, userPrivateKey, inputToken, address(uniAgent));
 
         // should still succeed even re-approve the token
         vm.startPrank(user);

--- a/test/forkMainnet/UniAgent/V2.t.sol
+++ b/test/forkMainnet/UniAgent/V2.t.sol
@@ -103,9 +103,10 @@ contract V2Test is UniAgentTest {
         uint256 outputAmount = amounts[amounts.length - 1];
 
         bytes memory payload = abi.encodeCall(IUniswapRouterV2.swapExactTokensForTokens, (defaultInputAmount, outputAmount, path, recipient, defaultExpiry));
+        bytes memory userPermit = getTokenlonPermit2Data(userPrivateKey, inputToken, address(uniAgent));
 
         vm.prank(user);
-        uniAgent.approveAndSwap(IUniAgent.RouterType.V2Router, inputToken, defaultInputAmount, payload, defaultUserPermit);
+        uniAgent.approveAndSwap(IUniAgent.RouterType.V2Router, inputToken, defaultInputAmount, payload, userPermit);
 
         userInputToken.assertChange(-int256(defaultInputAmount));
         // recipient should receive exact amount of quote from Uniswap
@@ -133,13 +134,14 @@ contract V2Test is UniAgentTest {
         uint256 outputAmount = amounts[amounts.length - 1];
 
         bytes memory payload = abi.encodeCall(IUniswapRouterV2.swapExactTokensForTokens, (defaultInputAmount, outputAmount, path, recipient, defaultExpiry));
+        bytes memory userPermit = getTokenlonPermit2Data(userPrivateKey, inputToken, address(uniAgent));
 
         // should still succeed even re-approve the token
         vm.startPrank(user);
         address[] memory approveList = new address[](1);
         approveList[0] = inputToken;
         uniAgent.approveTokensToRouters(approveList);
-        uniAgent.approveAndSwap(IUniAgent.RouterType.V2Router, inputToken, defaultInputAmount, payload, defaultUserPermit);
+        uniAgent.approveAndSwap(IUniAgent.RouterType.V2Router, inputToken, defaultInputAmount, payload, userPermit);
         vm.stopPrank();
 
         userInputToken.assertChange(-int256(defaultInputAmount));

--- a/test/utils/Permit2Helper.sol
+++ b/test/utils/Permit2Helper.sol
@@ -31,16 +31,20 @@ contract Permit2Helper is Test {
     }
 
     function getTokenlonPermit2Data(
-        uint256 privateKey,
+        address owner,
+        uint256 ownerPrivateKey,
         address token,
         address spender
     ) public view returns (bytes memory) {
+        uint256 expiration = block.timestamp + 1 days;
+        (, , uint48 nonce) = permit2.allowance(owner, token, spender);
+
         IUniswapPermit2.PermitSingle memory permit = IUniswapPermit2.PermitSingle({
-            details: IUniswapPermit2.PermitDetails({ token: token, amount: type(uint160).max, expiration: uint48(block.timestamp + 1 days), nonce: uint48(0) }),
+            details: IUniswapPermit2.PermitDetails({ token: token, amount: type(uint160).max, expiration: uint48(expiration), nonce: nonce }),
             spender: spender,
-            sigDeadline: block.timestamp + 1 days
+            sigDeadline: expiration
         });
-        bytes memory permitSig = signPermitSingle(privateKey, permit);
+        bytes memory permitSig = signPermitSingle(ownerPrivateKey, permit);
         return encodePermit2Data(permit, permitSig);
     }
 }

--- a/test/utils/Permit2Helper.sol
+++ b/test/utils/Permit2Helper.sol
@@ -13,10 +13,20 @@ contract Permit2Helper is Test {
         keccak256(
             "PermitSingle(PermitDetails details,address spender,uint256 sigDeadline)PermitDetails(address token,uint160 amount,uint48 expiration,uint48 nonce)"
         );
+    bytes32 public constant TOKEN_PERMISSIONS_TYPEHASH = keccak256("TokenPermissions(address token,uint256 amount)");
+    bytes32 public constant PERMIT_TRANSFER_FROM_TYPEHASH =
+        keccak256(
+            "PermitTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline)TokenPermissions(address token,uint256 amount)"
+        );
 
     function getPermitSingleHash(IUniswapPermit2.PermitSingle memory permit) public pure returns (bytes32) {
         bytes32 permitDetailsHash = keccak256(abi.encode(PERMIT_DETAILS_TYPEHASH, permit.details));
         return keccak256(abi.encode(PERMIT_SINGLE_TYPEHASH, permitDetailsHash, permit.spender, permit.sigDeadline));
+    }
+
+    function getPermitTransferFromHash(IUniswapPermit2.PermitTransferFrom memory permit, address spender) private pure returns (bytes32) {
+        bytes32 structHashTokenPermissions = keccak256(abi.encode(TOKEN_PERMISSIONS_TYPEHASH, permit.permitted));
+        return keccak256(abi.encode(PERMIT_TRANSFER_FROM_TYPEHASH, structHashTokenPermissions, spender, permit.nonce, permit.deadline));
     }
 
     function signPermitSingle(uint256 privateKey, IUniswapPermit2.PermitSingle memory permitSingle) public view returns (bytes memory) {
@@ -26,10 +36,31 @@ contract Permit2Helper is Test {
         return abi.encodePacked(r, s, v);
     }
 
-    function encodePermit2Data(IUniswapPermit2.PermitSingle memory permit, bytes memory permitSig) public pure returns (bytes memory) {
-        return abi.encodePacked(TokenCollector.Source.Permit2AllowanceTransfer, abi.encode(permit.details.nonce, permit.details.expiration, permitSig));
+    function signPermitTransferFrom(
+        uint256 privateKey,
+        IUniswapPermit2.PermitTransferFrom memory permitTransferFrom,
+        address spender
+    ) public view returns (bytes memory) {
+        bytes32 permitTransferFromHash = getPermitTransferFromHash(permitTransferFrom, spender);
+        bytes32 EIP712SignDigest = getEIP712Hash(permit2.DOMAIN_SEPARATOR(), permitTransferFromHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, EIP712SignDigest);
+        return abi.encodePacked(r, s, v);
     }
 
+    function encodeAllowanceTransfer(
+        address owner,
+        IUniswapPermit2.PermitSingle memory permit,
+        bytes memory permitSig
+    ) public pure returns (bytes memory) {
+        bytes memory permit2Calldata = abi.encode(owner, permit, permitSig);
+        return abi.encodePacked(TokenCollector.Source.Permit2AllowanceTransfer, permit2Calldata);
+    }
+
+    function encodeSignatureTransfer(IUniswapPermit2.PermitTransferFrom memory permit, bytes memory permitSig) public pure returns (bytes memory) {
+        return abi.encodePacked(TokenCollector.Source.Permit2SignatureTransfer, abi.encode(permit.nonce, permit.deadline, permitSig));
+    }
+
+    // will return encoded AllownaceTransfer data
     function getTokenlonPermit2Data(
         address owner,
         uint256 ownerPrivateKey,
@@ -45,6 +76,6 @@ contract Permit2Helper is Test {
             sigDeadline: expiration
         });
         bytes memory permitSig = signPermitSingle(ownerPrivateKey, permit);
-        return encodePermit2Data(permit, permitSig);
+        return encodeAllowanceTransfer(owner, permit, permitSig);
     }
 }

--- a/test/utils/Permit2Helper.sol
+++ b/test/utils/Permit2Helper.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import { IUniswapPermit2 } from "contracts/interfaces/IUniswapPermit2.sol";
+import { TokenCollector } from "contracts/abstracts/TokenCollector.sol";
+import { getEIP712Hash } from "test/utils/Sig.sol";
+import { Test } from "forge-std/Test.sol";
+
+contract Permit2Helper is Test {
+    IUniswapPermit2 public constant permit2 = IUniswapPermit2(0x000000000022D473030F116dDEE9F6B43aC78BA3);
+    bytes32 public constant PERMIT_DETAILS_TYPEHASH = keccak256("PermitDetails(address token,uint160 amount,uint48 expiration,uint48 nonce)");
+    bytes32 public constant PERMIT_SINGLE_TYPEHASH =
+        keccak256(
+            "PermitSingle(PermitDetails details,address spender,uint256 sigDeadline)PermitDetails(address token,uint160 amount,uint48 expiration,uint48 nonce)"
+        );
+
+    function getPermitSingleHash(IUniswapPermit2.PermitSingle memory permit) public pure returns (bytes32) {
+        bytes32 permitDetailsHash = keccak256(abi.encode(PERMIT_DETAILS_TYPEHASH, permit.details));
+        return keccak256(abi.encode(PERMIT_SINGLE_TYPEHASH, permitDetailsHash, permit.spender, permit.sigDeadline));
+    }
+
+    function signPermitSingle(uint256 privateKey, IUniswapPermit2.PermitSingle memory permitSingle) public view returns (bytes memory) {
+        bytes32 permitSingleHash = getPermitSingleHash(permitSingle);
+        bytes32 EIP712SignDigest = getEIP712Hash(permit2.DOMAIN_SEPARATOR(), permitSingleHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, EIP712SignDigest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function encodePermit2Data(IUniswapPermit2.PermitSingle memory permit, bytes memory permitSig) public pure returns (bytes memory) {
+        return abi.encodePacked(TokenCollector.Source.Permit2AllowanceTransfer, abi.encode(permit.details.nonce, permit.details.expiration, permitSig));
+    }
+
+    function getTokenlonPermit2Data(
+        uint256 privateKey,
+        address token,
+        address spender
+    ) public view returns (bytes memory) {
+        IUniswapPermit2.PermitSingle memory permit = IUniswapPermit2.PermitSingle({
+            details: IUniswapPermit2.PermitDetails({ token: token, amount: type(uint160).max, expiration: uint48(block.timestamp + 1 days), nonce: uint48(0) }),
+            spender: spender,
+            sigDeadline: block.timestamp + 1 days
+        });
+        bytes memory permitSig = signPermitSingle(privateKey, permit);
+        return encodePermit2Data(permit, permitSig);
+    }
+}


### PR DESCRIPTION
The `AllowanceTrasfer` should be called with max(uint160) as amount so it can be done just once. It's not equal to say that we enforce user to set the allowance to max. A user can call `Permit2` contract directly to setup whatever amount they want before swap. But in `TokenCollector`, it works like a bundled call so I think `max(uint160)` should be suitable for most cases.