### PR TITLE
adjust RFQ event amount fields

### DIFF
--- a/contracts/RFQ.sol
+++ b/contracts/RFQ.sol
@@ -148,25 +148,25 @@ contract RFQ is IRFQ, Ownable, TokenCollector, EIP712 {
             makerToken.transferTo(_rfqTx.recipient, makerTokenToTaker);
         }
 
-        _emitFilledRFQEvent(rfqOfferHash, _rfqTx, makerTokenToTaker);
+        _emitFilledRFQEvent(rfqOfferHash, _rfqTx, makerTokenToTaker, fee);
     }
 
     function _emitFilledRFQEvent(
         bytes32 _rfqOfferHash,
         RFQTx calldata _rfqTx,
-        uint256 _makerTokenToTaker
+        uint256 _makerTokenToTaker,
+        uint256 fee
     ) internal {
         emit FilledRFQ(
             _rfqOfferHash,
             _rfqTx.rfqOffer.taker,
             _rfqTx.rfqOffer.maker,
             _rfqTx.rfqOffer.takerToken,
-            _rfqTx.rfqOffer.takerTokenAmount,
+            _rfqTx.takerRequestAmount,
             _rfqTx.rfqOffer.makerToken,
-            _rfqTx.rfqOffer.makerTokenAmount,
-            _rfqTx.recipient,
             _makerTokenToTaker,
-            _rfqTx.rfqOffer.feeFactor
+            _rfqTx.recipient,
+            fee
         );
     }
 }

--- a/contracts/interfaces/IRFQ.sol
+++ b/contracts/interfaces/IRFQ.sol
@@ -23,12 +23,11 @@ interface IRFQ {
         address indexed user,
         address indexed maker,
         address takerToken,
-        uint256 takerTokenAmount,
+        uint256 takerTokenUserAmount,
         address makerToken,
-        uint256 makerTokenAmount,
+        uint256 makerTokenUserAmount,
         address recipient,
-        uint256 settleAmount,
-        uint256 feeFactor
+        uint256 fee
     );
 
     event CancelRFQOffer(bytes32 indexed rfqOfferHash, address indexed maker);

--- a/test/forkMainnet/RFQ.t.sol
+++ b/test/forkMainnet/RFQ.t.sol
@@ -28,12 +28,11 @@ contract RFQTest is Test, Tokens, BalanceUtil {
         address indexed user,
         address indexed maker,
         address takerToken,
-        uint256 takerTokenAmount,
+        uint256 takerTokenUserAmount,
         address makerToken,
-        uint256 makerTokenAmount,
+        uint256 makerTokenUserAmount,
         address recipient,
-        uint256 settleAmount,
-        uint256 feeFactor
+        uint256 fee
     );
     event SetFeeCollector(address newFeeCollector);
 
@@ -137,10 +136,9 @@ contract RFQTest is Test, Tokens, BalanceUtil {
             defaultRFQOffer.takerToken,
             defaultRFQOffer.takerTokenAmount,
             defaultRFQOffer.makerToken,
-            defaultRFQOffer.makerTokenAmount,
-            recipient,
             amountAfterFee,
-            defaultFeeFactor
+            recipient,
+            fee
         );
 
         vm.prank(defaultRFQOffer.taker, defaultRFQOffer.taker);
@@ -188,7 +186,6 @@ contract RFQTest is Test, Tokens, BalanceUtil {
             defaultRFQOffer.makerToken,
             defaultRFQOffer.makerTokenAmount,
             recipient,
-            defaultRFQOffer.makerTokenAmount,
             0
         );
 
@@ -482,10 +479,9 @@ contract RFQTest is Test, Tokens, BalanceUtil {
             defaultRFQOffer.takerToken,
             defaultRFQOffer.takerTokenAmount,
             defaultRFQOffer.makerToken,
-            defaultRFQOffer.makerTokenAmount,
-            recipient,
             amountAfterFee,
-            defaultFeeFactor
+            recipient,
+            fee
         );
 
         vm.prank(txRelayer, txRelayer);


### PR DESCRIPTION
Consider the partial fill case, emit with actual settle amount instead of original amount in the order.