### PR TITLE
refactor foundry config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@ coverage/
 coverage.json
 
 # Foundry
-artifacts/
+out/
 cache/

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,19 +1,9 @@
 [profile.default]
 src = 'contracts'                                             # the source directory
-test = 'test'                                                 # the test directory
-out = 'artifacts'                                             # the output directory (for artifacts)
-cache = true                                                  # whether to cache builds or not
-force = false                                                 # whether to ignore the cache (clean build)
 solc_version = "0.8.17"
 optimizer = true                                              # enable or disable the solc optimizer
 optimizer_runs = 1000                                         # the number of optimizer runs
 verbosity = 3                                                 # The verbosity of tests
-ignored_error_codes = []                                      # a list of ignored solc error codes
-block_number = 10000
-block_timestamp = 1640966400                                  # 2022/01/01 00:00
-initial_balance = '0xffffffffffffffffffffffff'                # the initial balance of the test contract
-gas_limit = 9223372036854775807                               # the gas limit in tests
-gas_price = 0                                                 # the gas price (in wei) in tests
 fs_permissions = [{ access = "read", path = "./test/utils/config/"}]
 
 [profile.ci]


### PR DESCRIPTION
Seems like `slither` doesn't work with non-default foundry output path. Also, remove default configs in file to make it clear.