### PR TITLE
cache array length

### DIFF
--- a/contracts/UniAgent.sol
+++ b/contracts/UniAgent.sol
@@ -24,7 +24,8 @@ contract UniAgent is IUniAgent, Ownable, TokenCollector {
     receive() external payable {}
 
     function rescueTokens(address[] calldata tokens, address recipient) external onlyOwner {
-        for (uint256 i = 0; i < tokens.length; ++i) {
+        uint256 tokensLength = tokens.length;
+        for (uint256 i = 0; i < tokensLength; ++i) {
             uint256 selfBalance = Asset.getBalance(tokens[i], address(this));
             if (selfBalance > 0) {
                 Asset.transferTo(tokens[i], payable(recipient), selfBalance);
@@ -33,7 +34,8 @@ contract UniAgent is IUniAgent, Ownable, TokenCollector {
     }
 
     function approveTokensToRouters(address[] calldata tokens) external {
-        for (uint256 i = 0; i < tokens.length; ++i) {
+        uint256 tokensLength = tokens.length;
+        for (uint256 i = 0; i < tokensLength; ++i) {
             // use low level call to avoid return size check
             // ignore return value and proceed anyway since three calls are independent
             tokens[i].call(abi.encodeWithSelector(IERC20.approve.selector, v2Router, type(uint256).max));

--- a/contracts/abstracts/AdminManagement.sol
+++ b/contracts/abstracts/AdminManagement.sol
@@ -15,15 +15,18 @@ abstract contract AdminManagement is Ownable {
     constructor(address _owner) Ownable(_owner) {}
 
     function approveTokens(address[] calldata tokens, address[] calldata spenders) external onlyOwner {
-        for (uint256 i = 0; i < tokens.length; ++i) {
-            for (uint256 j = 0; j < spenders.length; ++j) {
+        uint256 tokensLength = tokens.length;
+        uint256 spendersLength = spenders.length;
+        for (uint256 i = 0; i < tokensLength; ++i) {
+            for (uint256 j = 0; j < spendersLength; ++j) {
                 IERC20(tokens[i]).safeApprove(spenders[j], type(uint256).max);
             }
         }
     }
 
     function rescueTokens(address[] calldata tokens, address recipient) external onlyOwner {
-        for (uint256 i = 0; i < tokens.length; ++i) {
+        uint256 tokensLength = tokens.length;
+        for (uint256 i = 0; i < tokensLength; ++i) {
             uint256 selfBalance = Asset.getBalance(tokens[i], address(this));
             if (selfBalance > 0) {
                 Asset.transferTo(tokens[i], payable(recipient), selfBalance);


### PR DESCRIPTION
Cache array length in `fillLimitOrderGroup` function of LimitOrderSwap contract will cause stack overflow. Considered it save just a little gas, keep it unchanged now.