### PR TITLE
Revert "cache array length"

### DIFF
--- a/contracts/UniAgent.sol
+++ b/contracts/UniAgent.sol
@@ -24,8 +24,7 @@ contract UniAgent is IUniAgent, Ownable, TokenCollector {
     receive() external payable {}
 
     function rescueTokens(address[] calldata tokens, address recipient) external onlyOwner {
-        uint256 tokensLength = tokens.length;
-        for (uint256 i = 0; i < tokensLength; ++i) {
+        for (uint256 i = 0; i < tokens.length; ++i) {
             uint256 selfBalance = Asset.getBalance(tokens[i], address(this));
             if (selfBalance > 0) {
                 Asset.transferTo(tokens[i], payable(recipient), selfBalance);
@@ -34,8 +33,7 @@ contract UniAgent is IUniAgent, Ownable, TokenCollector {
     }
 
     function approveTokensToRouters(address[] calldata tokens) external {
-        uint256 tokensLength = tokens.length;
-        for (uint256 i = 0; i < tokensLength; ++i) {
+        for (uint256 i = 0; i < tokens.length; ++i) {
             // use low level call to avoid return size check
             // ignore return value and proceed anyway since three calls are independent
             tokens[i].call(abi.encodeCall(IERC20.approve, (v2Router, type(uint256).max)));

--- a/contracts/abstracts/AdminManagement.sol
+++ b/contracts/abstracts/AdminManagement.sol
@@ -15,18 +15,15 @@ abstract contract AdminManagement is Ownable {
     constructor(address _owner) Ownable(_owner) {}
 
     function approveTokens(address[] calldata tokens, address[] calldata spenders) external onlyOwner {
-        uint256 tokensLength = tokens.length;
-        uint256 spendersLength = spenders.length;
-        for (uint256 i = 0; i < tokensLength; ++i) {
-            for (uint256 j = 0; j < spendersLength; ++j) {
+        for (uint256 i = 0; i < tokens.length; ++i) {
+            for (uint256 j = 0; j < spenders.length; ++j) {
                 IERC20(tokens[i]).safeApprove(spenders[j], type(uint256).max);
             }
         }
     }
 
     function rescueTokens(address[] calldata tokens, address recipient) external onlyOwner {
-        uint256 tokensLength = tokens.length;
-        for (uint256 i = 0; i < tokensLength; ++i) {
+        for (uint256 i = 0; i < tokens.length; ++i) {
             uint256 selfBalance = Asset.getBalance(tokens[i], address(this));
             if (selfBalance > 0) {
                 Asset.transferTo(tokens[i], payable(recipient), selfBalance);


### PR DESCRIPTION
Caching array length of a calldata array actually increase the gas consumption instead. Revert the previous change.