### PR TITLE
gas optimization: leave one wei feature

### DIFF
--- a/contracts/GenericSwap.sol
+++ b/contracts/GenericSwap.sol
@@ -67,9 +67,7 @@ contract GenericSwap is IGenericSwap, TokenCollector, EIP712 {
 
         if (_inputToken.isETH()) {
             if (msg.value != _swapData.takerTokenAmount) revert InvalidMsgValue();
-        }
-
-        if (!_inputToken.isETH()) {
+        } else {
             if (msg.value != 0) revert InvalidMsgValue();
             _collect(_inputToken, _authorizedUser, _swapData.maker, _swapData.takerTokenAmount, _takerTokenPermit);
         }
@@ -77,6 +75,11 @@ contract GenericSwap is IGenericSwap, TokenCollector, EIP712 {
         IStrategy(_swapData.maker).executeStrategy{ value: msg.value }(_inputToken, _outputToken, _swapData.takerTokenAmount, _swapData.strategyData);
 
         returnAmount = _outputToken.getBalance(address(this));
+        if (returnAmount > 1) {
+            unchecked {
+                --returnAmount;
+            }
+        }
         if (returnAmount < _swapData.minMakerTokenAmount) revert InsufficientOutput();
 
         _outputToken.transferTo(_swapData.recipient, returnAmount);

--- a/contracts/SmartOrderStrategy.sol
+++ b/contracts/SmartOrderStrategy.sol
@@ -70,8 +70,8 @@ contract SmartOrderStrategy is ISmartOrderStrategy, AdminManagement {
 
         // replace amount if ratio != 0
         if (_inputRatio != 0) {
-            // leave one wei
             uint256 inputTokenBalance = IERC20(_inputToken).balanceOf(address(this));
+            // leaving one wei for gas optimization
             if (inputTokenBalance > 1) {
                 unchecked {
                     --inputTokenBalance;

--- a/contracts/SmartOrderStrategy.sol
+++ b/contracts/SmartOrderStrategy.sol
@@ -57,6 +57,11 @@ contract SmartOrderStrategy is ISmartOrderStrategy, AdminManagement {
             }
         }
         uint256 selfBalance = Asset.getBalance(outputToken, address(this));
+        if (selfBalance > 1) {
+            unchecked {
+                --selfBalance;
+            }
+        }
         Asset.transferTo(outputToken, payable(genericSwap), selfBalance);
     }
 
@@ -65,7 +70,13 @@ contract SmartOrderStrategy is ISmartOrderStrategy, AdminManagement {
 
         // replace amount if ratio != 0
         if (_inputRatio != 0) {
+            // leave one wei
             uint256 inputTokenBalance = IERC20(_inputToken).balanceOf(address(this));
+            if (inputTokenBalance > 1) {
+                unchecked {
+                    --inputTokenBalance;
+                }
+            }
 
             // calculate input amount if ratio should be applied
             if (_inputRatio != Constant.BPS_MAX) {

--- a/contracts/libraries/GenericSwapData.sol
+++ b/contracts/libraries/GenericSwapData.sol
@@ -21,6 +21,7 @@ struct GenericSwapData {
 }
 
 // solhint-disable-next-line func-visibility
+// free functions cannot have function visibility
 function getGSDataHash(GenericSwapData memory gsData) pure returns (bytes32) {
     return
         keccak256(

--- a/test/forkMainnet/GenericSwap.t.sol
+++ b/test/forkMainnet/GenericSwap.t.sol
@@ -157,17 +157,17 @@ contract GenericSwapTest is Test, Tokens, BalanceUtil, Permit2Helper, SigHelper 
         Snapshot memory makerMakerToken = BalanceSnapshot.take({ owner: address(mockStrategy), token: gsData.makerToken });
 
         uint256 actualOutput = 900;
-        uint256 realChangedInGas = actualOutput - 1;
+        uint256 realChangedInGS = actualOutput - 1; // leaving 1 wei in GS
 
         // 800 < 900 < 1000
         mockStrategy.setOutputAmountAndRecipient(actualOutput, payable(address(genericSwap)));
         vm.expectEmit(true, true, true, true);
-        emit Swap(getGSDataHash(gsData), gsData.maker, taker, taker, gsData.takerToken, gsData.takerTokenAmount, gsData.makerToken, realChangedInGas);
+        emit Swap(getGSDataHash(gsData), gsData.maker, taker, taker, gsData.takerToken, gsData.takerTokenAmount, gsData.makerToken, realChangedInGS);
         vm.prank(taker);
         genericSwap.executeSwap(gsData, defaultTakerPermit);
 
         takerTakerToken.assertChange(-int256(gsData.takerTokenAmount));
-        takerMakerToken.assertChange(int256(realChangedInGas));
+        takerMakerToken.assertChange(int256(realChangedInGS));
         makerTakerToken.assertChange(int256(gsData.takerTokenAmount));
         makerMakerToken.assertChange(-int256(actualOutput));
     }
@@ -178,6 +178,8 @@ contract GenericSwapTest is Test, Tokens, BalanceUtil, Permit2Helper, SigHelper 
         gsData.takerToken = Constant.ETH_ADDRESS;
         gsData.takerTokenAmount = 1 ether;
 
+        uint256 realChangedInGS = gsData.makerTokenAmount - 1; // leaving 1 wei in GS
+
         Snapshot memory takerTakerToken = BalanceSnapshot.take({ owner: taker, token: gsData.takerToken });
         Snapshot memory takerMakerToken = BalanceSnapshot.take({ owner: taker, token: gsData.makerToken });
         Snapshot memory makerTakerToken = BalanceSnapshot.take({ owner: address(mockStrategy), token: gsData.takerToken });
@@ -185,21 +187,12 @@ contract GenericSwapTest is Test, Tokens, BalanceUtil, Permit2Helper, SigHelper 
 
         mockStrategy.setOutputAmountAndRecipient(gsData.makerTokenAmount, payable(address(genericSwap)));
         vm.expectEmit(true, true, true, true);
-        emit Swap(
-            getGSDataHash(gsData),
-            gsData.maker,
-            taker,
-            taker,
-            gsData.takerToken,
-            gsData.takerTokenAmount,
-            gsData.makerToken,
-            gsData.makerTokenAmount - 1
-        );
+        emit Swap(getGSDataHash(gsData), gsData.maker, taker, taker, gsData.takerToken, gsData.takerTokenAmount, gsData.makerToken, realChangedInGS);
         vm.prank(taker);
         genericSwap.executeSwap{ value: gsData.takerTokenAmount }(gsData, defaultTakerPermit);
 
         takerTakerToken.assertChange(-int256(gsData.takerTokenAmount));
-        takerMakerToken.assertChange(int256(gsData.makerTokenAmount - 1)); // leaving 1 wei in GS
+        takerMakerToken.assertChange(int256(realChangedInGS));
         makerTakerToken.assertChange(int256(gsData.takerTokenAmount));
         makerMakerToken.assertChange(-int256(gsData.makerTokenAmount));
     }
@@ -211,6 +204,8 @@ contract GenericSwapTest is Test, Tokens, BalanceUtil, Permit2Helper, SigHelper 
         gsData.makerTokenAmount = 1 ether;
         gsData.minMakerTokenAmount = 1 ether - 1000;
 
+        uint256 realChangedInGS = gsData.makerTokenAmount - 1; // leaving 1 wei in GS
+
         Snapshot memory takerTakerToken = BalanceSnapshot.take({ owner: taker, token: gsData.takerToken });
         Snapshot memory takerMakerToken = BalanceSnapshot.take({ owner: taker, token: gsData.makerToken });
         Snapshot memory makerTakerToken = BalanceSnapshot.take({ owner: address(mockStrategy), token: gsData.takerToken });
@@ -218,21 +213,12 @@ contract GenericSwapTest is Test, Tokens, BalanceUtil, Permit2Helper, SigHelper 
 
         mockStrategy.setOutputAmountAndRecipient(gsData.makerTokenAmount, payable(address(genericSwap)));
         vm.expectEmit(true, true, true, true);
-        emit Swap(
-            getGSDataHash(gsData),
-            gsData.maker,
-            taker,
-            taker,
-            gsData.takerToken,
-            gsData.takerTokenAmount,
-            gsData.makerToken,
-            gsData.makerTokenAmount - 1
-        );
+        emit Swap(getGSDataHash(gsData), gsData.maker, taker, taker, gsData.takerToken, gsData.takerTokenAmount, gsData.makerToken, realChangedInGS);
         vm.prank(taker);
         genericSwap.executeSwap(gsData, defaultTakerPermit);
 
         takerTakerToken.assertChange(-int256(gsData.takerTokenAmount));
-        takerMakerToken.assertChange(int256(gsData.makerTokenAmount - 1)); // leaving 1 wei in GS
+        takerMakerToken.assertChange(int256(realChangedInGS));
         makerTakerToken.assertChange(int256(gsData.takerTokenAmount));
         makerMakerToken.assertChange(-int256(gsData.makerTokenAmount));
     }

--- a/test/forkMainnet/GenericSwap.t.sol
+++ b/test/forkMainnet/GenericSwap.t.sol
@@ -62,6 +62,9 @@ contract GenericSwapTest is Test, Tokens, BalanceUtil, Permit2Helper, SigHelper 
 
         genericSwap = new GenericSwap(UNISWAP_PERMIT2_ADDRESS, address(allowanceTarget));
         smartStrategy = new SmartOrderStrategy(strategyAdmin, address(genericSwap), WETH_ADDRESS);
+
+        deal(DAI_ADDRESS, address(smartStrategy), 1 wei);
+
         mockStrategy = new MockStrategy();
         vm.prank(strategyAdmin);
         address[] memory tokenList = new address[](1);

--- a/test/forkMainnet/GenericSwap.t.sol
+++ b/test/forkMainnet/GenericSwap.t.sol
@@ -63,7 +63,10 @@ contract GenericSwapTest is Test, Tokens, BalanceUtil, Permit2Helper, SigHelper 
         genericSwap = new GenericSwap(UNISWAP_PERMIT2_ADDRESS, address(allowanceTarget));
         smartStrategy = new SmartOrderStrategy(strategyAdmin, address(genericSwap), WETH_ADDRESS);
 
+        // deposit 1 wei in SOR and GS
         deal(DAI_ADDRESS, address(smartStrategy), 1 wei);
+        deal(DAI_ADDRESS, address(genericSwap), 1 wei);
+        deal(address(genericSwap), 1 wei);
 
         mockStrategy = new MockStrategy();
         vm.prank(strategyAdmin);

--- a/test/forkMainnet/SmartOrderStrategy/AMMs.t.sol
+++ b/test/forkMainnet/SmartOrderStrategy/AMMs.t.sol
@@ -208,7 +208,7 @@ contract AMMsTest is SmartOrderStrategyTest {
             )
         );
 
-        // exhange function selector : 0x5b41b908
+        // exchange function selector : 0x5b41b908
         bytes memory curveData = abi.encodeWithSelector(0x5b41b908, 2, 0, uniOut, 0);
         ICurveFiV2 curvePool = ICurveFiV2(CURVE_TRICRYPTO2_POOL_ADDRESS);
         uint256 curveOut = curvePool.get_dy(2, 0, uniOut);

--- a/test/forkMainnet/SmartOrderStrategy/IntegrationV6.t.sol
+++ b/test/forkMainnet/SmartOrderStrategy/IntegrationV6.t.sol
@@ -46,6 +46,9 @@ contract IntegrationV6Test is SmartOrderStrategyTest, SigHelper {
         vm.prank(strategyOwner);
         smartOrderStrategy.approveTokens(tokenList, spenders);
 
+        deal(LON_ADDRESS, address(smartOrderStrategy), 1 wei);
+        deal(DAI_ADDRESS, address(smartOrderStrategy), 1 wei);
+
         // maker approves RFQ & LO
         setTokenBalanceAndApprove(maker, address(rfq), tokens, 100000);
         setTokenBalanceAndApprove(maker, address(limitOrderSwap), tokens, 100000);

--- a/test/forkMainnet/SmartOrderStrategy/Setup.t.sol
+++ b/test/forkMainnet/SmartOrderStrategy/Setup.t.sol
@@ -40,11 +40,6 @@ contract SmartOrderStrategyTest is Test, Tokens, BalanceUtil {
             setERC20Balance(tokenList[i], genericSwap, 10000);
         }
 
-        deal(USDC_ADDRESS, address(smartOrderStrategy), 1 wei);
-        deal(USDT_ADDRESS, address(smartOrderStrategy), 1 wei);
-        deal(WETH_ADDRESS, address(smartOrderStrategy), 1 wei);
-        deal(WBTC_ADDRESS, address(smartOrderStrategy), 1 wei);
-
         SmartOrderStrategy.Operation[] memory operations = new SmartOrderStrategy.Operation[](1);
         defaultOpsData = abi.encode(operations);
 

--- a/test/forkMainnet/SmartOrderStrategy/Setup.t.sol
+++ b/test/forkMainnet/SmartOrderStrategy/Setup.t.sol
@@ -40,6 +40,11 @@ contract SmartOrderStrategyTest is Test, Tokens, BalanceUtil {
             setERC20Balance(tokenList[i], genericSwap, 10000);
         }
 
+        deal(USDC_ADDRESS, address(smartOrderStrategy), 1 wei);
+        deal(USDT_ADDRESS, address(smartOrderStrategy), 1 wei);
+        deal(WETH_ADDRESS, address(smartOrderStrategy), 1 wei);
+        deal(WBTC_ADDRESS, address(smartOrderStrategy), 1 wei);
+
         SmartOrderStrategy.Operation[] memory operations = new SmartOrderStrategy.Operation[](1);
         defaultOpsData = abi.encode(operations);
 


### PR DESCRIPTION
For gas optimization purposes, we retain 1 wei of each token in our contract(GS and SOS). This will impact the initial swap of every token, as 1 wei will be left in our contract.

- Implement the logic for leaving 1 wei in `GenericSwap.sol`
- Implement the logic for leaving 1 wei in `SmartOrderStrategy.sol`