### PR TITLE
fix: activate isolate mode in toml

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -6,6 +6,7 @@ solc_version = "0.8.17"
 optimizer = true # enable or disable the solc optimizer
 optimizer_runs = 1000 # the number of optimizer runs
 verbosity = 3 # The verbosity of tests
+isolate = true # enable or disable the isolate mode for calculating gas usage correctly
 fs_permissions = [
     { access = "read", path = "./test/utils/config/" },
     { access = "read", path = "./test/utils/payload/" },


### PR DESCRIPTION
# Motivation
To ensure our gas diff CI reports the correct gas usage and accurately reflects the difference between two commits.

# Solution
- Add `isolate = true` setting in the `foundry.toml` file. This will ensure the correct gas usage when executing `forge test` or `forge script`.
 
FYI: the `isolate` mode is introduced in [7186](https://github.com/foundry-rs/foundry/pull/7186)