### PR TITLE
specify evm version: Shanghai

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,6 +2,7 @@
 src = 'contracts' # the source directory
 cache = true # whether to cache builds or not
 force = false # whether to ignore the cache (clean build)
+evm_version = "shanghai"
 solc_version = "0.8.26"
 optimizer = true # enable or disable the solc optimizer
 optimizer_runs = 1000 # the number of optimizer runs


### PR DESCRIPTION
This PR sets the default EVM version (`Paris`) to `Shanghai`. The reason for this change is that all the multi-chain networks supported by Tokenlon have already adopted the `Shanghai` upgrade.

