### PR TITLE
add gas measurement to tests and refactor some test structures

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,6 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
-	branch = v5.0.2
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
-	branch = v1.3.0

--- a/snapshots/AdminManagement.json
+++ b/snapshots/AdminManagement.json
@@ -1,0 +1,4 @@
+{
+  "approveTokens(): testApproveTokens": "136967",
+  "rescueTokens(): testRescueTokens": "86851"
+}

--- a/snapshots/AllowanceTarget.json
+++ b/snapshots/AllowanceTarget.json
@@ -1,0 +1,8 @@
+{
+  "pause(): testSpendFromUserToAfterUnpause": "27667",
+  "spendFromUserTo(): testSpendFromUserTo": "63533",
+  "spendFromUserTo(): testSpendFromUserToAfterUnpause": "63533",
+  "spendFromUserTo(): testSpendFromUserToWithDeflationaryToken": "91576",
+  "spendFromUserTo(): testSpendFromUserToWithNoReturnValueToken": "68943",
+  "unpause(): testSpendFromUserToAfterUnpause": "27645"
+}

--- a/snapshots/Asset.json
+++ b/snapshots/Asset.json
@@ -1,0 +1,11 @@
+{
+  "getBalance(): testGetBalance": "6107",
+  "getBalance(): testGetBalance(ETH_ADDRESS)": "764",
+  "getBalance(): testGetBalance(ZERO_ADDRESS)": "781",
+  "isETH(): testIsETH(ETH_ADDRESS)": "441",
+  "isETH(): testIsETH2(ZERO_ADDRESS)": "458",
+  "transferTo(): testDoNothingIfTransferToSelf": "22431",
+  "transferTo(): testDoNothingIfTransferWithZeroAmount": "22419",
+  "transferTo(): testTransferETH": "57012",
+  "transferTo(): testTransferToken": "51501"
+}

--- a/snapshots/CoordinatedTaker.json
+++ b/snapshots/CoordinatedTaker.json
@@ -1,0 +1,6 @@
+{
+  "approveTokens(): testApproveTokens": "54307",
+  "setCoordinator(): testSetCoordinator": "30043",
+  "submitLimitOrderFill(): testFillWithETH": "192971",
+  "submitLimitOrderFill(): testFillWithPermission": "256473"
+}

--- a/snapshots/EIP712.json
+++ b/snapshots/EIP712.json
@@ -1,0 +1,5 @@
+{
+  "EIP712_DOMAIN_SEPARATOR(): testDomainSeparatorOnChain": "276",
+  "EIP712_DOMAIN_SEPARATOR(): testDomainSeparatorOnDifferentChain": "626",
+  "getEIP712Hash(): testGetEIP712Hash": "828"
+}

--- a/snapshots/GenericSwap.json
+++ b/snapshots/GenericSwap.json
@@ -1,0 +1,9 @@
+{
+  "executeSwap(): testGenericSwapWithUniswap": "251909",
+  "executeSwap(): testLeaveOneWeiWithMultipleUsers(the first deposit)": "251909",
+  "executeSwap(): testLeaveOneWeiWithMultipleUsers(the second deposit)": "208263",
+  "executeSwap(): testSwapWithETHInput": "100382",
+  "executeSwap(): testSwapWithETHOutput": "130241",
+  "executeSwap(): testSwapWithLessOutputButWithinTolerance": "160688",
+  "executeSwapWithSig(): testGenericSwapRelayed": "283756"
+}

--- a/snapshots/LimitOrderSwap.json
+++ b/snapshots/LimitOrderSwap.json
@@ -1,0 +1,20 @@
+{
+  "cancelOrder(): testCancelOrder": "52753",
+  "fillLimitOrder(): testFillLimitOrderWithETH": "158029",
+  "fillLimitOrder(): testFillWithBetterTakingAmount": "215471",
+  "fillLimitOrder(): testFillWithBetterTakingAmountButGetAdjusted": "215705",
+  "fillLimitOrder(): testFillWithETHRefund": "165308",
+  "fillLimitOrder(): testFillWithLargerVolumeAndSettleAsManyAsPossible": "215693",
+  "fillLimitOrder(): testFillWithoutMakerSigForVerifiedOrder": "215471",
+  "fillLimitOrder(): testFillWithoutMakerSigForVerifiedOrder(without makerSig)": "120983",
+  "fillLimitOrder(): testFullyFillLimitOrder": "215471",
+  "fillLimitOrder(): testFullyFillLimitOrderUsingAMM": "235046",
+  "fillLimitOrder(): testPartiallyFillLimitOrder": "215471",
+  "fillLimitOrderFullOrKill(): testFillWithFOK": "215449",
+  "fillLimitOrderGroup(): testGroupFillRingTrade": "291749",
+  "fillLimitOrderGroup(): testGroupFillWithPartialWETHUnwrap": "277818",
+  "fillLimitOrderGroup(): testGroupFillWithTakerPrefundETH": "198117",
+  "fillLimitOrderGroup(): testGroupFillWithWETHUnwrap": "198117",
+  "fillLimitOrderGroup(): testPartialFillLargeOrderWithSmallOrders": "265910",
+  "testGroupFillWithProfit: fillLimitOrderGroup()": "225225"
+}

--- a/snapshots/Ownable.json
+++ b/snapshots/Ownable.json
@@ -1,0 +1,5 @@
+{
+  "acceptOwnership(): testAcceptOwnership": "28390",
+  "nominateNewOwner(): testNominateNewOwner": "47132",
+  "renounceOwnership(): testRenounceOwnership": "25351"
+}

--- a/snapshots/RFQ.json
+++ b/snapshots/RFQ.json
@@ -1,0 +1,15 @@
+{
+  "cancelRFQOffer(): testCancelRFQOffer": "49848",
+  "fillRFQ(): testFillRFQ": "219666",
+  "fillRFQ(): testFillRFQTakerGetRawETH": "238797",
+  "fillRFQ(): testFillRFQWithRawETH": "159563",
+  "fillRFQ(): testFillRFQWithRawETHAndReceiveWETH": "174630",
+  "fillRFQ(): testFillRFQWithTakerApproveAllowanceTarget": "187631",
+  "fillRFQ(): testFillRFQWithWETH": "222131",
+  "fillRFQ(): testFillRFQWithWETHAndReceiveWETH": "208373",
+  "fillRFQ(): testFillRFQWithZeroFee": "192740",
+  "fillRFQ(): testFillWithContract": "223381",
+  "fillRFQ(): testPartialFill": "219826",
+  "fillRFQWithSig(): testFillRFQByTakerSig": "228592",
+  "setFeeCollector(): testSetFeeCollector": "30099"
+}

--- a/snapshots/SmartOrderStrategy.json
+++ b/snapshots/SmartOrderStrategy.json
@@ -1,0 +1,11 @@
+{
+  "executeStrategy(): testMultipleAMMs": "610173",
+  "executeStrategy(): testUniswapV2WithWETHUnwrap": "142340",
+  "executeStrategy(): testUniswapV3WithAmountReplace": "161811",
+  "executeStrategy(): testUniswapV3WithMaxAmountReplace": "161607",
+  "executeStrategy(): testUniswapV3WithoutAmountReplace": "155017",
+  "executeStrategy(): testV6LOIntegration": "180661",
+  "executeStrategy(): testV6RFQIntegration": "183394",
+  "executeStrategy(): testV6RFQIntegrationWhenMakerTokenIsETH": "149739",
+  "executeStrategy(): testV6RFQIntegrationWhenTakerTokenIsETH": "204956"
+}

--- a/snapshots/TokenCollector.json
+++ b/snapshots/TokenCollector.json
@@ -1,0 +1,7 @@
+{
+  "collect(): testCollectByAllowanceTarget": "66338",
+  "collect(): testCollectByPermit2AllowanceTransfer": "102281",
+  "collect(): testCollectByPermit2SignatureTransfer": "94388",
+  "collect(): testCollectByTokenApproval": "58597",
+  "collect(): testCollectByTokenPermit": "93729"
+}

--- a/test/abstracts/AdminManagement.t.sol
+++ b/test/abstracts/AdminManagement.t.sol
@@ -31,17 +31,19 @@ contract AdminManagementTest is BalanceUtil {
     }
 
     function testApproveTokens() public {
-        for (uint256 i = 0; i < tokens.length; ++i) {
-            for (uint256 j = 0; j < spenders.length; ++j) {
+        for (uint256 i; i < tokens.length; ++i) {
+            for (uint256 j; j < spenders.length; ++j) {
                 assertEq(IERC20(tokens[i]).allowance(address(contractWithAdmin), spenders[j]), 0);
             }
         }
 
-        vm.prank(owner);
+        vm.startPrank(owner);
         contractWithAdmin.approveTokens(tokens, spenders);
+        vm.stopPrank();
+        vm.snapshotGasLastCall("AdminManagement", "approveTokens(): testApproveTokens");
 
-        for (uint256 i = 0; i < tokens.length; ++i) {
-            for (uint256 j = 0; j < spenders.length; ++j) {
+        for (uint256 i; i < tokens.length; ++i) {
+            for (uint256 j; j < spenders.length; ++j) {
                 assertEq(IERC20(tokens[i]).allowance(address(contractWithAdmin), spenders[j]), type(uint256).max);
             }
         }
@@ -63,8 +65,10 @@ contract AdminManagementTest is BalanceUtil {
         assertEq(IERC20(tokens[1]).balanceOf(address(contractWithAdmin)), amount2);
         assertEq(IERC20(tokens[1]).balanceOf(rescueTarget), 0);
 
-        vm.prank(owner);
+        vm.startPrank(owner);
         contractWithAdmin.rescueTokens(tokens, rescueTarget);
+        vm.stopPrank();
+        vm.snapshotGasLastCall("AdminManagement", "rescueTokens(): testRescueTokens");
 
         assertEq(IERC20(tokens[0]).balanceOf(address(contractWithAdmin)), 0);
         assertEq(IERC20(tokens[0]).balanceOf(rescueTarget), amount1);

--- a/test/abstracts/EIP712.t.sol
+++ b/test/abstracts/EIP712.t.sol
@@ -5,48 +5,55 @@ import { Test } from "forge-std/Test.sol";
 import { EIP712 } from "contracts/abstracts/EIP712.sol";
 
 contract EIP712Test is Test {
-    EIP712TestContract eip712;
+    EIP712Harness eip712Harness;
 
     // Dummy struct hash for testing
     bytes32 public constant DUMMY_STRUCT_HASH = keccak256("DummyStruct(string message)");
 
     function setUp() public {
-        eip712 = new EIP712TestContract();
+        eip712Harness = new EIP712Harness();
     }
 
     function testOriginalChainId() public {
         uint256 chainId = block.chainid;
-        assertEq(eip712.originalChainId(), chainId);
+        assertEq(eip712Harness.originalChainId(), chainId);
     }
 
     function testOriginalDomainSeparator() public {
-        bytes32 expectedDomainSeparator = eip712.calculateDomainSeparator();
-        assertEq(eip712.originalEIP712DomainSeparator(), expectedDomainSeparator);
+        bytes32 expectedDomainSeparator = eip712Harness.calculateDomainSeparator();
+        assertEq(eip712Harness.originalEIP712DomainSeparator(), expectedDomainSeparator);
     }
 
     function testGetEIP712Hash() public {
         bytes32 structHash = DUMMY_STRUCT_HASH;
-        bytes32 domainSeparator = eip712.calculateDomainSeparator();
-        bytes32 expectedEIP712Hash = keccak256(abi.encodePacked(eip712.EIP191_HEADER(), domainSeparator, structHash));
+        bytes32 domainSeparator = eip712Harness.calculateDomainSeparator();
+        bytes32 expectedEIP712Hash = keccak256(abi.encodePacked(eip712Harness.EIP191_HEADER(), domainSeparator, structHash));
 
-        assertEq(eip712.getEIP712HashWrap(structHash), expectedEIP712Hash);
+        assertEq(eip712Harness.exposedGetEIP712Hash(structHash), expectedEIP712Hash);
+        vm.snapshotGasLastCall("EIP712", "getEIP712Hash(): testGetEIP712Hash");
     }
 
     function testDomainSeparatorOnDifferentChain() public {
         uint256 chainId = block.chainid + 1234;
         vm.chainId(chainId);
 
-        bytes32 newDomainSeparator = eip712.calculateDomainSeparator();
-        assertEq(eip712.EIP712_DOMAIN_SEPARATOR(), newDomainSeparator, "Domain separator should match the expected value on a different chain");
+        bytes32 newDomainSeparator = eip712Harness.calculateDomainSeparator();
+        assertEq(eip712Harness.EIP712_DOMAIN_SEPARATOR(), newDomainSeparator, "Domain separator should match the expected value on a different chain");
+        vm.snapshotGasLastCall("EIP712", "EIP712_DOMAIN_SEPARATOR(): testDomainSeparatorOnDifferentChain");
+    }
+
+    function testDomainSeparatorOnChain() public {
+        eip712Harness.EIP712_DOMAIN_SEPARATOR();
+        vm.snapshotGasLastCall("EIP712", "EIP712_DOMAIN_SEPARATOR(): testDomainSeparatorOnChain");
     }
 }
 
-contract EIP712TestContract is EIP712 {
+contract EIP712Harness is EIP712 {
     function calculateDomainSeparator() external view returns (bytes32) {
         return keccak256(abi.encode(EIP712_TYPE_HASH, keccak256(bytes(EIP712_NAME)), keccak256(bytes(EIP712_VERSION)), block.chainid, address(this)));
     }
 
-    function getEIP712HashWrap(bytes32 structHash) public view returns (bytes32) {
-        return super.getEIP712Hash(structHash);
+    function exposedGetEIP712Hash(bytes32 structHash) public view returns (bytes32) {
+        return getEIP712Hash(structHash);
     }
 }

--- a/test/abstracts/Ownable.t.sol
+++ b/test/abstracts/Ownable.t.sol
@@ -13,8 +13,9 @@ contract OwnableTest is Test {
     address otherAccount = makeAddr("otherAccount");
 
     function setUp() public {
-        vm.prank(owner);
+        vm.startPrank(owner);
         ownable = new OwnableTestContract(owner);
+        vm.stopPrank();
     }
 
     function testOwnableInitialState() public {
@@ -27,64 +28,80 @@ contract OwnableTest is Test {
     }
 
     function testCannotAcceptOwnershipWithOtherAccount() public {
-        vm.prank(owner);
+        vm.startPrank(owner);
         ownable.nominateNewOwner(newOwner);
+        vm.stopPrank();
 
-        vm.prank(otherAccount);
+        vm.startPrank(otherAccount);
         vm.expectRevert(Ownable.NotNominated.selector);
         ownable.acceptOwnership();
+        vm.stopPrank();
     }
 
     function testCannotRenounceOwnershipWithNominatedOwner() public {
-        vm.prank(owner);
+        vm.startPrank(owner);
         ownable.nominateNewOwner(newOwner);
+        vm.stopPrank();
 
-        vm.prank(owner);
+        vm.startPrank(owner);
         vm.expectRevert(Ownable.NominationExists.selector);
         ownable.renounceOwnership();
+        vm.stopPrank();
     }
 
     function testCannotRenounceOwnershipWithOtherAccount() public {
-        vm.prank(otherAccount);
+        vm.startPrank(otherAccount);
         vm.expectRevert(Ownable.NotOwner.selector);
         ownable.renounceOwnership();
+        vm.stopPrank();
     }
 
     function testCannotNominateNewOwnerWithOtherAccount() public {
-        vm.prank(otherAccount);
+        vm.startPrank(otherAccount);
         vm.expectRevert(Ownable.NotOwner.selector);
         ownable.nominateNewOwner(newOwner);
+        vm.stopPrank();
     }
 
     function testAcceptOwnership() public {
-        vm.prank(owner);
+        vm.startPrank(owner);
         ownable.nominateNewOwner(newOwner);
+        vm.stopPrank();
 
         assertEq(ownable.nominatedOwner(), newOwner);
 
-        vm.prank(newOwner);
         vm.expectEmit(true, true, false, false);
         emit Ownable.OwnerChanged(owner, newOwner);
+
+        vm.startPrank(newOwner);
         ownable.acceptOwnership();
+        vm.stopPrank();
+        vm.snapshotGasLastCall("Ownable", "acceptOwnership(): testAcceptOwnership");
 
         assertEq(ownable.owner(), newOwner);
         assertEq(ownable.nominatedOwner(), address(0));
     }
 
     function testRenounceOwnership() public {
-        vm.prank(owner);
         vm.expectEmit(true, true, false, false);
         emit Ownable.OwnerChanged(owner, address(0));
+
+        vm.startPrank(owner);
         ownable.renounceOwnership();
+        vm.stopPrank();
+        vm.snapshotGasLastCall("Ownable", "renounceOwnership(): testRenounceOwnership");
 
         assertEq(ownable.owner(), address(0));
     }
 
     function testNominateNewOwner() public {
-        vm.prank(owner);
         vm.expectEmit(true, false, false, false);
         emit Ownable.OwnerNominated(newOwner);
+
+        vm.startPrank(owner);
         ownable.nominateNewOwner(newOwner);
+        vm.stopPrank();
+        vm.snapshotGasLastCall("Ownable", "nominateNewOwner(): testNominateNewOwner");
 
         assertEq(ownable.nominatedOwner(), newOwner);
     }

--- a/test/forkMainnet/LimitOrderSwap/Fill.t.sol
+++ b/test/forkMainnet/LimitOrderSwap/Fill.t.sol
@@ -52,8 +52,10 @@ contract FillTest is LimitOrderSwapTest {
             recipient
         );
 
-        vm.prank(taker);
+        vm.startPrank(taker);
         limitOrderSwap.fillLimitOrder({ order: defaultOrder, makerSignature: defaultMakerSig, takerParams: defaultTakerParams });
+        vm.stopPrank();
+        vm.snapshotGasLastCall("LimitOrderSwap", "fillLimitOrder(): testFullyFillLimitOrder");
 
         takerTakerToken.assertChange(-int256(defaultOrder.takerTokenAmount));
         takerMakerToken.assertChange(int256(0));
@@ -101,7 +103,7 @@ contract FillTest is LimitOrderSwapTest {
             address(mockLimitOrderTaker)
         );
 
-        vm.prank(address(mockLimitOrderTaker));
+        vm.startPrank(address(mockLimitOrderTaker));
         limitOrderSwap.fillLimitOrder({
             order: order,
             makerSignature: makerSig,
@@ -113,6 +115,8 @@ contract FillTest is LimitOrderSwapTest {
                 takerTokenPermit: directApprovePermit
             })
         });
+        vm.stopPrank();
+        vm.snapshotGasLastCall("LimitOrderSwap", "fillLimitOrder(): testFullyFillLimitOrderUsingAMM");
 
         // taker should not have token balance changes
         takerTakerToken.assertChange(int256(0));
@@ -132,7 +136,7 @@ contract FillTest is LimitOrderSwapTest {
         Snapshot memory fcMakerToken = BalanceSnapshot.take({ owner: feeCollector, token: defaultOrder.makerToken });
 
         uint256 takingAmount = defaultOrder.takerTokenAmount / 2;
-        uint256 makingAmount = defaultOrder.takerTokenAmount / 2;
+        uint256 makingAmount = defaultOrder.makerTokenAmount / 2;
         uint256 fee = (makingAmount * defaultFeeFactor) / Constant.BPS_MAX;
 
         vm.expectEmit(true, true, true, true);
@@ -151,8 +155,10 @@ contract FillTest is LimitOrderSwapTest {
         takerParams.takerTokenAmount = takingAmount;
         takerParams.makerTokenAmount = makingAmount;
 
-        vm.prank(taker);
+        vm.startPrank(taker);
         limitOrderSwap.fillLimitOrder({ order: defaultOrder, makerSignature: defaultMakerSig, takerParams: takerParams });
+        vm.stopPrank();
+        vm.snapshotGasLastCall("LimitOrderSwap", "fillLimitOrder(): testPartiallyFillLimitOrder");
 
         takerTakerToken.assertChange(-int256(takingAmount));
         takerMakerToken.assertChange(int256(0));
@@ -194,7 +200,7 @@ contract FillTest is LimitOrderSwapTest {
             recipient
         );
 
-        vm.prank(taker);
+        vm.startPrank(taker);
         limitOrderSwap.fillLimitOrder{ value: order.takerTokenAmount }({
             order: order,
             makerSignature: makerSig,
@@ -206,6 +212,8 @@ contract FillTest is LimitOrderSwapTest {
                 takerTokenPermit: defaultTakerPermit
             })
         });
+        vm.stopPrank();
+        vm.snapshotGasLastCall("LimitOrderSwap", "fillLimitOrder(): testFillLimitOrderWithETH");
 
         takerTakerToken.assertChange(-int256(order.takerTokenAmount));
         takerMakerToken.assertChange(int256(0));
@@ -245,8 +253,10 @@ contract FillTest is LimitOrderSwapTest {
             recipient
         );
 
-        vm.prank(taker);
+        vm.startPrank(taker);
         limitOrderSwap.fillLimitOrder({ order: defaultOrder, makerSignature: defaultMakerSig, takerParams: takerParams });
+        vm.stopPrank();
+        vm.snapshotGasLastCall("LimitOrderSwap", "fillLimitOrder(): testFillWithBetterTakingAmount");
 
         takerTakerToken.assertChange(-int256(actualTokenAmount));
         takerMakerToken.assertChange(int256(0));
@@ -284,7 +294,7 @@ contract FillTest is LimitOrderSwapTest {
             recipient
         );
 
-        vm.prank(taker);
+        vm.startPrank(taker);
         limitOrderSwap.fillLimitOrder({
             order: defaultOrder,
             makerSignature: defaultMakerSig,
@@ -296,6 +306,8 @@ contract FillTest is LimitOrderSwapTest {
                 takerTokenPermit: defaultTakerPermit
             })
         });
+        vm.stopPrank();
+        vm.snapshotGasLastCall("LimitOrderSwap", "fillLimitOrder(): testFillWithLargerVolumeAndSettleAsManyAsPossible");
 
         takerTakerToken.assertChange(-int256(defaultOrder.takerTokenAmount));
         takerMakerToken.assertChange(int256(0));
@@ -308,7 +320,7 @@ contract FillTest is LimitOrderSwapTest {
 
     function testFillWithBetterTakingAmountButGetAdjusted() public {
         // fill with better price but the order doesn't have enough for the requested
-        // so the makingAmount == order's avaliable amount
+        // so the makingAmount == order's available amount
         // takingAmount should be adjusted to keep the original price that taker provided
         Snapshot memory takerTakerToken = BalanceSnapshot.take({ owner: taker, token: defaultOrder.takerToken });
         Snapshot memory takerMakerToken = BalanceSnapshot.take({ owner: taker, token: defaultOrder.makerToken });
@@ -346,8 +358,10 @@ contract FillTest is LimitOrderSwapTest {
             recipient
         );
 
-        vm.prank(taker);
+        vm.startPrank(taker);
         limitOrderSwap.fillLimitOrder({ order: defaultOrder, makerSignature: defaultMakerSig, takerParams: takerParams });
+        vm.stopPrank();
+        vm.snapshotGasLastCall("LimitOrderSwap", "fillLimitOrder(): testFillWithBetterTakingAmountButGetAdjusted");
 
         takerTakerToken.assertChange(-int256(settleTakingAMount));
         takerMakerToken.assertChange(int256(0));
@@ -402,7 +416,7 @@ contract FillTest is LimitOrderSwapTest {
             recipient
         );
 
-        vm.prank(taker);
+        vm.startPrank(taker);
         limitOrderSwap.fillLimitOrder{ value: traderTakingAmount }({
             order: order,
             makerSignature: makerSig,
@@ -414,6 +428,8 @@ contract FillTest is LimitOrderSwapTest {
                 takerTokenPermit: defaultTakerPermit
             })
         });
+        vm.stopPrank();
+        vm.snapshotGasLastCall("LimitOrderSwap", "fillLimitOrder(): testFillWithETHRefund");
 
         takerTakerToken.assertChange(-int256(order.takerTokenAmount));
         takerMakerToken.assertChange(int256(0));
@@ -425,33 +441,67 @@ contract FillTest is LimitOrderSwapTest {
     }
 
     function testFillWithoutMakerSigForVerifiedOrder() public {
+        uint256 takingAmount = defaultOrder.takerTokenAmount / 10;
+        uint256 makingAmount = defaultOrder.makerTokenAmount / 10;
+        uint256 fee = (makingAmount * defaultFeeFactor) / Constant.BPS_MAX;
+
+        vm.expectEmit(true, true, true, true);
+        emit LimitOrderFilled(
+            getLimitOrderHash(defaultOrder),
+            taker,
+            defaultOrder.maker,
+            defaultOrder.takerToken,
+            takingAmount,
+            defaultOrder.makerToken,
+            makingAmount - fee,
+            fee,
+            recipient
+        );
+
         // fill default order first with 1/10 amount
-        vm.prank(taker);
+        vm.startPrank(taker);
         limitOrderSwap.fillLimitOrder({
             order: defaultOrder,
             makerSignature: defaultMakerSig,
             takerParams: ILimitOrderSwap.TakerParams({
-                takerTokenAmount: defaultOrder.takerTokenAmount / 10,
-                makerTokenAmount: defaultOrder.makerTokenAmount / 10,
+                takerTokenAmount: takingAmount,
+                makerTokenAmount: makingAmount,
                 recipient: recipient,
                 extraAction: bytes(""),
                 takerTokenPermit: defaultTakerPermit
             })
         });
+        vm.stopPrank();
+        vm.snapshotGasLastCall("LimitOrderSwap", "fillLimitOrder(): testFillWithoutMakerSigForVerifiedOrder");
+
+        vm.expectEmit(true, true, true, true);
+        emit LimitOrderFilled(
+            getLimitOrderHash(defaultOrder),
+            taker,
+            defaultOrder.maker,
+            defaultOrder.takerToken,
+            takingAmount,
+            defaultOrder.makerToken,
+            makingAmount - fee,
+            fee,
+            recipient
+        );
 
         // fill default order again without makerSig
-        vm.prank(taker);
+        vm.startPrank(taker);
         limitOrderSwap.fillLimitOrder({
             order: defaultOrder,
             makerSignature: bytes(""),
             takerParams: ILimitOrderSwap.TakerParams({
-                takerTokenAmount: defaultOrder.takerTokenAmount / 10,
-                makerTokenAmount: defaultOrder.makerTokenAmount / 10,
+                takerTokenAmount: takingAmount,
+                makerTokenAmount: makingAmount,
                 recipient: recipient,
                 extraAction: bytes(""),
                 takerTokenPermit: allowanceTransferPermit
             })
         });
+        vm.stopPrank();
+        vm.snapshotGasLastCall("LimitOrderSwap", "fillLimitOrder(): testFillWithoutMakerSigForVerifiedOrder(without makerSig)");
     }
 
     function testCannotFillWithNotEnoughTakingAmount() public {
@@ -460,9 +510,10 @@ contract FillTest is LimitOrderSwapTest {
         ILimitOrderSwap.TakerParams memory takerParams = defaultTakerParams;
         takerParams.takerTokenAmount = actualTokenAmount;
 
+        vm.startPrank(taker);
         vm.expectRevert(ILimitOrderSwap.InvalidTakingAmount.selector);
-        vm.prank(taker);
         limitOrderSwap.fillLimitOrder({ order: defaultOrder, makerSignature: defaultMakerSig, takerParams: takerParams });
+        vm.stopPrank();
     }
 
     function testCannotFillIfStrategyNotReturnEnoughTakingAmount() public {
@@ -495,9 +546,10 @@ contract FillTest is LimitOrderSwapTest {
     function testCannotFillExpiredOrder() public {
         vm.warp(defaultOrder.expiry + 1);
 
+        vm.startPrank(taker);
         vm.expectRevert(ILimitOrderSwap.ExpiredOrder.selector);
-        vm.prank(taker);
         limitOrderSwap.fillLimitOrder({ order: defaultOrder, makerSignature: defaultMakerSig, takerParams: defaultTakerParams });
+        vm.stopPrank();
     }
 
     function testCannotFillByNotSpecifiedTaker() public {
@@ -505,73 +557,83 @@ contract FillTest is LimitOrderSwapTest {
         order.taker = makeAddr("specialTaker");
         bytes memory makerSig = signLimitOrder(makerPrivateKey, order, address(limitOrderSwap));
 
+        vm.startPrank(makeAddr("randomTaker"));
         vm.expectRevert(ILimitOrderSwap.InvalidTaker.selector);
-        vm.prank(makeAddr("randomTaker"));
         limitOrderSwap.fillLimitOrder({ order: order, makerSignature: makerSig, takerParams: defaultTakerParams });
+        vm.stopPrank();
     }
 
     function testCannotFillCanceledOrder() public {
-        vm.prank(maker);
+        vm.startPrank(maker);
         limitOrderSwap.cancelOrder(defaultOrder);
+        vm.stopPrank();
 
+        vm.startPrank(taker);
         vm.expectRevert(ILimitOrderSwap.CanceledOrder.selector);
-        vm.prank(taker);
         limitOrderSwap.fillLimitOrder({ order: defaultOrder, makerSignature: defaultMakerSig, takerParams: defaultTakerParams });
+        vm.stopPrank();
     }
 
     function testCannotFillWithIncorrectMakerSig() public {
         uint256 randomPrivateKey = 5677;
         bytes memory makerSig = signLimitOrder(randomPrivateKey, defaultOrder, address(limitOrderSwap));
 
+        vm.startPrank(taker);
         vm.expectRevert(ILimitOrderSwap.InvalidSignature.selector);
-        vm.prank(taker);
         limitOrderSwap.fillLimitOrder({ order: defaultOrder, makerSignature: makerSig, takerParams: defaultTakerParams });
+        vm.stopPrank();
     }
 
     function testCannotTradeFilledOrder() public {
-        vm.prank(taker);
+        vm.startPrank(taker);
         limitOrderSwap.fillLimitOrder({ order: defaultOrder, makerSignature: defaultMakerSig, takerParams: defaultTakerParams });
+        vm.stopPrank();
 
+        vm.startPrank(taker);
         vm.expectRevert(ILimitOrderSwap.FilledOrder.selector);
-        vm.prank(taker);
         limitOrderSwap.fillLimitOrder({ order: defaultOrder, makerSignature: defaultMakerSig, takerParams: defaultTakerParams });
+        vm.stopPrank();
     }
 
     function testCannotFillWithIncorrectMsgValue() public {
         // case1 : takerToken is not ETH but msg.value != 0
+        vm.startPrank(taker);
         vm.expectRevert(ILimitOrderSwap.InvalidMsgValue.selector);
-        vm.prank(taker);
         limitOrderSwap.fillLimitOrder{ value: 100 }({ order: defaultOrder, makerSignature: defaultMakerSig, takerParams: defaultTakerParams });
+        vm.stopPrank();
 
         LimitOrder memory order = defaultOrder;
         order.takerToken = Constant.ETH_ADDRESS;
         bytes memory makerSig = signLimitOrder(makerPrivateKey, order, address(limitOrderSwap));
 
         // case2 : takerToken is ETH but msg.value > takingAmount
+        vm.startPrank(taker);
         vm.expectRevert(ILimitOrderSwap.InvalidMsgValue.selector);
-        vm.prank(taker);
         limitOrderSwap.fillLimitOrder{ value: defaultTakerParams.takerTokenAmount + 1 }({
             order: order,
             makerSignature: makerSig,
             takerParams: defaultTakerParams
         });
+        vm.stopPrank();
 
         // case3 : takerToken is ETH but msg.value < takingAmount
+        vm.startPrank(taker);
         vm.expectRevert(ILimitOrderSwap.InvalidMsgValue.selector);
-        vm.prank(taker);
         limitOrderSwap.fillLimitOrder{ value: defaultTakerParams.takerTokenAmount - 1 }({
             order: order,
             makerSignature: makerSig,
             takerParams: defaultTakerParams
         });
+        vm.stopPrank();
     }
 
     function testCannotFillWithZeroRecipient() public {
         ILimitOrderSwap.TakerParams memory takerParams = defaultTakerParams;
         takerParams.recipient = address(0);
 
+        vm.startPrank(taker);
         vm.expectRevert(ILimitOrderSwap.ZeroAddress.selector);
-        vm.prank(taker);
         limitOrderSwap.fillLimitOrder({ order: defaultOrder, makerSignature: defaultMakerSig, takerParams: takerParams });
+        vm.stopPrank();
     }
 }

--- a/test/forkMainnet/LimitOrderSwap/FullOrKill.t.sol
+++ b/test/forkMainnet/LimitOrderSwap/FullOrKill.t.sol
@@ -37,7 +37,7 @@ contract FullOrKillTest is LimitOrderSwapTest {
             recipient
         );
 
-        vm.prank(taker);
+        vm.startPrank(taker);
         limitOrderSwap.fillLimitOrderFullOrKill({
             order: defaultOrder,
             makerSignature: defaultMakerSig,
@@ -49,6 +49,8 @@ contract FullOrKillTest is LimitOrderSwapTest {
                 takerTokenPermit: defaultTakerPermit
             })
         });
+        vm.stopPrank();
+        vm.snapshotGasLastCall("LimitOrderSwap", "fillLimitOrderFullOrKill(): testFillWithFOK");
 
         takerTakerToken.assertChange(-int256(traderTakingAmount));
         takerMakerToken.assertChange(int256(0));
@@ -64,8 +66,8 @@ contract FullOrKillTest is LimitOrderSwapTest {
         uint256 traderMakingAmount = defaultOrder.makerTokenAmount * 2;
         uint256 traderTakingAmount = defaultOrder.takerTokenAmount * 2;
 
+        vm.startPrank(taker);
         vm.expectRevert(ILimitOrderSwap.NotEnoughForFill.selector);
-        vm.prank(taker);
         limitOrderSwap.fillLimitOrderFullOrKill({
             order: defaultOrder,
             makerSignature: defaultMakerSig,
@@ -77,6 +79,7 @@ contract FullOrKillTest is LimitOrderSwapTest {
                 takerTokenPermit: defaultTakerPermit
             })
         });
+        vm.stopPrank();
     }
 
     function testCannotFillFOKIfNotEnoughEvenPriceIsBetter() public {
@@ -84,8 +87,8 @@ contract FullOrKillTest is LimitOrderSwapTest {
         uint256 traderMakingAmount = defaultOrder.makerTokenAmount * 2;
         uint256 traderTakingAmount = defaultOrder.takerTokenAmount * 20;
 
+        vm.startPrank(taker);
         vm.expectRevert(ILimitOrderSwap.NotEnoughForFill.selector);
-        vm.prank(taker);
         limitOrderSwap.fillLimitOrderFullOrKill({
             order: defaultOrder,
             makerSignature: defaultMakerSig,
@@ -97,5 +100,6 @@ contract FullOrKillTest is LimitOrderSwapTest {
                 takerTokenPermit: defaultTakerPermit
             })
         });
+        vm.stopPrank();
     }
 }

--- a/test/forkMainnet/LimitOrderSwap/GroupFill.t.sol
+++ b/test/forkMainnet/LimitOrderSwap/GroupFill.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import { ILimitOrderSwap } from "contracts/interfaces/ILimitOrderSwap.sol";
 import { IUniswapPermit2 } from "contracts/interfaces/IUniswapPermit2.sol";
 import { LimitOrder, getLimitOrderHash } from "contracts/libraries/LimitOrder.sol";
 import { Constant } from "contracts/libraries/Constant.sol";
@@ -83,8 +82,11 @@ contract GroupFillTest is LimitOrderSwapTest {
         address[] memory profitTokens = new address[](1);
         profitTokens[0] = DAI_ADDRESS;
         Snapshot memory arbProfitToken = BalanceSnapshot.take({ owner: arbitrageur, token: DAI_ADDRESS });
-        vm.prank(arbitrageur, arbitrageur);
+
+        vm.startPrank(arbitrageur);
         limitOrderSwap.fillLimitOrderGroup({ orders: orders, makerSignatures: makerSigs, makerTokenAmounts: makerTokenAmounts, profitTokens: profitTokens });
+        vm.stopPrank();
+        vm.snapshotGasLastCall("LimitOrderSwap", "testGroupFillWithProfit: fillLimitOrderGroup()");
 
         // two makers should give/get exactly as order specified
         maker0TakerToken.assertChange(int256(orders[0].takerTokenAmount));
@@ -155,7 +157,11 @@ contract GroupFillTest is LimitOrderSwapTest {
         Snapshot memory maker2MakerToken = BalanceSnapshot.take({ owner: orders[2].maker, token: orders[2].makerToken });
 
         address[] memory profitTokens;
+
+        vm.startPrank(arbitrageur);
         limitOrderSwap.fillLimitOrderGroup({ orders: orders, makerSignatures: makerSigs, makerTokenAmounts: makerTokenAmounts, profitTokens: profitTokens });
+        vm.stopPrank();
+        vm.snapshotGasLastCall("LimitOrderSwap", "fillLimitOrderGroup(): testPartialFillLargeOrderWithSmallOrders");
 
         // small orders maker should be fully filled
         maker0TakerToken.assertChange(int256(orders[0].takerTokenAmount));
@@ -211,7 +217,11 @@ contract GroupFillTest is LimitOrderSwapTest {
         Snapshot memory maker1MakerToken = BalanceSnapshot.take({ owner: orders[1].maker, token: orders[1].makerToken });
 
         address[] memory profitTokens;
+
+        vm.startPrank(arbitrageur);
         limitOrderSwap.fillLimitOrderGroup({ orders: orders, makerSignatures: makerSigs, makerTokenAmounts: makerTokenAmounts, profitTokens: profitTokens });
+        vm.stopPrank();
+        vm.snapshotGasLastCall("LimitOrderSwap", "fillLimitOrderGroup(): testGroupFillWithWETHUnwrap");
 
         // all orders should be fully filled
         maker0TakerToken.assertChange(int256(orders[0].takerTokenAmount));
@@ -289,8 +299,10 @@ contract GroupFillTest is LimitOrderSwapTest {
         profitTokens[0] = Constant.ETH_ADDRESS;
         Snapshot memory arbETHProfit = BalanceSnapshot.take({ owner: arbitrageur, token: Constant.ETH_ADDRESS });
 
-        vm.prank(arbitrageur, arbitrageur);
+        vm.startPrank(arbitrageur);
         limitOrderSwap.fillLimitOrderGroup({ orders: orders, makerSignatures: makerSigs, makerTokenAmounts: makerTokenAmounts, profitTokens: profitTokens });
+        vm.stopPrank();
+        vm.snapshotGasLastCall("LimitOrderSwap", "fillLimitOrderGroup(): testGroupFillWithPartialWETHUnwrap");
 
         // all orders should be fully filled
         maker0TakerToken.assertChange(int256(orders[0].takerTokenAmount));
@@ -353,13 +365,16 @@ contract GroupFillTest is LimitOrderSwapTest {
         uint256 takerPreFund = orders[1].takerTokenAmount - orders[0].makerTokenAmount;
 
         address[] memory profitTokens;
-        vm.prank(arbitrageur);
+
+        vm.startPrank(arbitrageur);
         limitOrderSwap.fillLimitOrderGroup{ value: takerPreFund }({
             orders: orders,
             makerSignatures: makerSigs,
             makerTokenAmounts: makerTokenAmounts,
             profitTokens: profitTokens
         });
+        vm.stopPrank();
+        vm.snapshotGasLastCall("LimitOrderSwap", "fillLimitOrderGroup(): testGroupFillWithTakerPrefundETH");
 
         // small orders maker should be fully filled
         maker0TakerToken.assertChange(int256(orders[0].takerTokenAmount));
@@ -428,7 +443,11 @@ contract GroupFillTest is LimitOrderSwapTest {
         Snapshot memory maker2MakerToken = BalanceSnapshot.take({ owner: orders[2].maker, token: orders[2].makerToken });
 
         address[] memory profitTokens;
+
+        vm.startPrank(arbitrageur);
         limitOrderSwap.fillLimitOrderGroup({ orders: orders, makerSignatures: makerSigs, makerTokenAmounts: makerTokenAmounts, profitTokens: profitTokens });
+        vm.stopPrank();
+        vm.snapshotGasLastCall("LimitOrderSwap", "fillLimitOrderGroup(): testGroupFillRingTrade");
 
         // all order should be fully filled
         maker0TakerToken.assertChange(int256(orders[0].takerTokenAmount));

--- a/test/forkMainnet/LimitOrderSwap/Management.t.sol
+++ b/test/forkMainnet/LimitOrderSwap/Management.t.sol
@@ -8,22 +8,28 @@ import { LimitOrderSwapTest } from "test/forkMainnet/LimitOrderSwap/Setup.t.sol"
 contract ManagementTest is LimitOrderSwapTest {
     function testCannotSetFeeCollectorByNotOwner() public {
         address newFeeCollector = makeAddr("newFeeCollector");
-        vm.prank(newFeeCollector);
+
+        vm.startPrank(newFeeCollector);
         vm.expectRevert(Ownable.NotOwner.selector);
         limitOrderSwap.setFeeCollector(payable(newFeeCollector));
+        vm.stopPrank();
     }
 
     function testCannotSetFeeCollectorToZero() public {
-        vm.prank(limitOrderOwner, limitOrderOwner);
+        vm.startPrank(limitOrderOwner);
         vm.expectRevert(ILimitOrderSwap.ZeroAddress.selector);
         limitOrderSwap.setFeeCollector(payable(address(0)));
+        vm.stopPrank();
     }
 
     function testSetFeeCollector() public {
         address newFeeCollector = makeAddr("newFeeCollector");
-        vm.prank(limitOrderOwner, limitOrderOwner);
-        limitOrderSwap.setFeeCollector(payable(newFeeCollector));
+
+        vm.expectEmit(false, false, false, true);
         emit SetFeeCollector(newFeeCollector);
-        assertEq(limitOrderSwap.feeCollector(), newFeeCollector);
+
+        vm.startPrank(limitOrderOwner);
+        limitOrderSwap.setFeeCollector(payable(newFeeCollector));
+        vm.stopPrank();
     }
 }

--- a/test/forkMainnet/LimitOrderSwap/Setup.t.sol
+++ b/test/forkMainnet/LimitOrderSwap/Setup.t.sol
@@ -93,8 +93,9 @@ contract LimitOrderSwapTest is Test, Tokens, BalanceUtil, Permit2Helper, SigHelp
         });
 
         // maker should call permit2 first independently
-        vm.prank(maker);
+        vm.startPrank(maker);
         IUniswapPermit2(UNISWAP_PERMIT2_ADDRESS).approve(defaultOrder.makerToken, address(limitOrderSwap), type(uint160).max, uint48(block.timestamp + 1 days));
+        vm.stopPrank();
 
         defaultTakerPermit = getTokenlonPermit2Data(taker, takerPrivateKey, defaultOrder.takerToken, address(limitOrderSwap));
 

--- a/test/forkMainnet/LimitOrderSwap/Validation.t.sol
+++ b/test/forkMainnet/LimitOrderSwap/Validation.t.sol
@@ -12,6 +12,7 @@ contract ValidationTest is LimitOrderSwapTest {
 
         bytes memory makerSig = signLimitOrder(makerPrivateKey, order, address(limitOrderSwap));
 
+        vm.startPrank(taker);
         vm.expectRevert(ILimitOrderSwap.ZeroTakerTokenAmount.selector);
         limitOrderSwap.fillLimitOrder({
             order: order,
@@ -24,6 +25,7 @@ contract ValidationTest is LimitOrderSwapTest {
                 takerTokenPermit: defaultTakerPermit
             })
         });
+        vm.stopPrank();
     }
 
     function testCannotFillLimitOrderWithZeroMakerTokenAmount() public {
@@ -32,6 +34,7 @@ contract ValidationTest is LimitOrderSwapTest {
 
         bytes memory makerSig = signLimitOrder(makerPrivateKey, order, address(limitOrderSwap));
 
+        vm.startPrank(taker);
         vm.expectRevert(ILimitOrderSwap.ZeroMakerTokenAmount.selector);
         limitOrderSwap.fillLimitOrder({
             order: order,
@@ -44,9 +47,11 @@ contract ValidationTest is LimitOrderSwapTest {
                 takerTokenPermit: defaultTakerPermit
             })
         });
+        vm.stopPrank();
     }
 
     function testCannotFillLimitOrderWithZeroTakerSpendingAmount() public {
+        vm.startPrank(taker);
         vm.expectRevert(ILimitOrderSwap.ZeroTakerSpendingAmount.selector);
         limitOrderSwap.fillLimitOrder({
             order: defaultOrder,
@@ -59,12 +64,13 @@ contract ValidationTest is LimitOrderSwapTest {
                 takerTokenPermit: defaultTakerPermit
             })
         });
+        vm.stopPrank();
     }
 
     function testCannotFillLimitOrderWithZeroTakerSpendingAmountWhenRecalculation() public {
         // this case tests if _takerTokenAmount is zero due to re-calculation.
+        vm.startPrank(taker);
         vm.expectRevert(ILimitOrderSwap.ZeroTakerSpendingAmount.selector);
-        vm.prank(taker);
         limitOrderSwap.fillLimitOrder({
             order: defaultOrder,
             makerSignature: defaultMakerSig,
@@ -76,9 +82,11 @@ contract ValidationTest is LimitOrderSwapTest {
                 takerTokenPermit: defaultTakerPermit
             })
         });
+        vm.stopPrank();
     }
 
     function testCannotFillLimitOrderWithZeroMakerSpendingAmount() public {
+        vm.startPrank(taker);
         vm.expectRevert(ILimitOrderSwap.ZeroMakerSpendingAmount.selector);
         limitOrderSwap.fillLimitOrder({
             order: defaultOrder,
@@ -91,6 +99,7 @@ contract ValidationTest is LimitOrderSwapTest {
                 takerTokenPermit: defaultTakerPermit
             })
         });
+        vm.stopPrank();
     }
 
     function testCannotFillLimitOrderGroupWithInvalidParams() public {
@@ -99,8 +108,10 @@ contract ValidationTest is LimitOrderSwapTest {
         uint256[] memory makerTokenAmounts = new uint256[](3);
         address[] memory profitTokens = new address[](1);
 
+        vm.startPrank(taker);
         vm.expectRevert(ILimitOrderSwap.InvalidParams.selector);
         limitOrderSwap.fillLimitOrderGroup({ orders: orders, makerSignatures: makerSigs, makerTokenAmounts: makerTokenAmounts, profitTokens: profitTokens });
+        vm.stopPrank();
     }
 
     function testCannotFillLimitOrderGroupWithNotEnoughForFill() public {
@@ -125,8 +136,10 @@ contract ValidationTest is LimitOrderSwapTest {
         makerSigs[0] = signLimitOrder(makerPrivateKey, orders[0], address(limitOrderSwap));
         makerTokenAmounts[0] = orders[0].makerTokenAmount + 1;
 
+        vm.startPrank(taker);
         vm.expectRevert(ILimitOrderSwap.NotEnoughForFill.selector);
         limitOrderSwap.fillLimitOrderGroup({ orders: orders, makerSignatures: makerSigs, makerTokenAmounts: makerTokenAmounts, profitTokens: profitTokens });
+        vm.stopPrank();
     }
 
     function testCannotFillLimitOrderGroupWithZeroMakerSpendingAmount() public {
@@ -151,7 +164,9 @@ contract ValidationTest is LimitOrderSwapTest {
         makerSigs[0] = signLimitOrder(makerPrivateKey, orders[0], address(limitOrderSwap));
         makerTokenAmounts[0] = 0;
 
+        vm.startPrank(taker);
         vm.expectRevert(ILimitOrderSwap.ZeroMakerSpendingAmount.selector);
         limitOrderSwap.fillLimitOrderGroup({ orders: orders, makerSignatures: makerSigs, makerTokenAmounts: makerTokenAmounts, profitTokens: profitTokens });
+        vm.stopPrank();
     }
 }

--- a/test/forkMainnet/SmartOrderStrategy/Setup.t.sol
+++ b/test/forkMainnet/SmartOrderStrategy/Setup.t.sol
@@ -31,8 +31,9 @@ contract SmartOrderStrategyTest is Test, Tokens, BalanceUtil {
     function setUp() public virtual {
         // Deploy and setup SmartOrderStrategy
         smartOrderStrategy = new SmartOrderStrategy(strategyOwner, genericSwap, WETH_ADDRESS);
-        vm.prank(strategyOwner);
+        vm.startPrank(strategyOwner);
         smartOrderStrategy.approveTokens(tokenList, ammList);
+        vm.stopPrank();
 
         // Make genericSwap rich to provide fund for strategy contract
         deal(genericSwap, 100 ether);

--- a/test/forkMainnet/SmartOrderStrategy/Validation.t.sol
+++ b/test/forkMainnet/SmartOrderStrategy/Validation.t.sol
@@ -12,9 +12,10 @@ contract ValidationTest is SmartOrderStrategyTest {
     }
 
     function testCannotExecuteWithZeroInputAmount() public {
+        vm.startPrank(genericSwap);
         vm.expectRevert(ISmartOrderStrategy.ZeroInput.selector);
-        vm.prank(genericSwap, genericSwap);
         smartOrderStrategy.executeStrategy(defaultInputToken, defaultOutputToken, 0, defaultOpsData);
+        vm.stopPrank();
     }
 
     function testCannotExecuteWithZeroRatioDenominatorWhenRatioNumeratorIsNonZero() public {
@@ -24,24 +25,27 @@ contract ValidationTest is SmartOrderStrategyTest {
         operations[0].ratioDenominator = 0;
         bytes memory opsData = abi.encode(operations);
 
+        vm.startPrank(genericSwap);
         vm.expectRevert(ISmartOrderStrategy.ZeroDenominator.selector);
-        vm.prank(genericSwap, genericSwap);
         smartOrderStrategy.executeStrategy(defaultInputToken, defaultOutputToken, defaultInputAmount, opsData);
+        vm.stopPrank();
     }
 
     function testCannotExecuteWithFailDecodedData() public {
+        vm.startPrank(genericSwap);
         vm.expectRevert();
-        vm.prank(genericSwap, genericSwap);
         smartOrderStrategy.executeStrategy(defaultInputToken, defaultOutputToken, defaultInputAmount, bytes("random data"));
+        vm.stopPrank();
     }
 
     function testCannotExecuteWithEmptyOperation() public {
         ISmartOrderStrategy.Operation[] memory operations;
         bytes memory emptyOpsData = abi.encode(operations);
 
+        vm.startPrank(genericSwap);
         vm.expectRevert(ISmartOrderStrategy.EmptyOps.selector);
-        vm.prank(genericSwap, genericSwap);
         smartOrderStrategy.executeStrategy(defaultInputToken, defaultOutputToken, defaultInputAmount, emptyOpsData);
+        vm.stopPrank();
     }
 
     function testCannotExecuteWithIncorrectMsgValue() public {
@@ -49,19 +53,22 @@ contract ValidationTest is SmartOrderStrategyTest {
         address inputToken = Constant.ETH_ADDRESS;
         uint256 inputAmount = 1 ether;
 
+        vm.startPrank(genericSwap);
         vm.expectRevert(ISmartOrderStrategy.InvalidMsgValue.selector);
-        vm.prank(genericSwap, genericSwap);
         smartOrderStrategy.executeStrategy{ value: inputAmount + 1 }(inputToken, defaultOutputToken, inputAmount, defaultOpsData);
+        vm.stopPrank();
 
         // case : ETH as input but msg.value is zero
+        vm.startPrank(genericSwap);
         vm.expectRevert(ISmartOrderStrategy.InvalidMsgValue.selector);
-        vm.prank(genericSwap, genericSwap);
         smartOrderStrategy.executeStrategy{ value: 0 }(inputToken, defaultOutputToken, inputAmount, defaultOpsData);
+        vm.stopPrank();
 
         // case : token as input but msg.value is not zero
+        vm.startPrank(genericSwap);
         vm.expectRevert(ISmartOrderStrategy.InvalidMsgValue.selector);
-        vm.prank(genericSwap, genericSwap);
         smartOrderStrategy.executeStrategy{ value: 1 }(defaultInputToken, defaultOutputToken, defaultInputAmount, defaultOpsData);
+        vm.stopPrank();
     }
 
     function testCannotExecuteAnOperationWillFail() public {
@@ -77,7 +84,7 @@ contract ValidationTest is SmartOrderStrategyTest {
         });
         bytes memory opsData = abi.encode(operations);
 
-        vm.startPrank(genericSwap, genericSwap);
+        vm.startPrank(genericSwap);
         vm.expectRevert();
         smartOrderStrategy.executeStrategy(defaultInputToken, defaultOutputToken, defaultInputAmount, opsData);
         vm.stopPrank();


### PR DESCRIPTION
- Update the `forge-std` library to v1.9.4, which supports the snapshotGasLastCall cheatcode.

- Add the `snapshotGasLastCall` cheatcode to tests for measuring gas usage.

- Refactor test structures to enhance consistency. (e.g. replace `vm.prank()` with `vm.startPrank()` and `vm.stopPrank()`).

- Fix a [bug](https://github.com/consenlabs/tokenlon-contracts/blob/master/test/forkMainnet/LimitOrderSwap/Fill.t.sol#L135) in a test function where `takerTokenAmount` and `makerTokenAmount` were misused.