### PR TITLE
specify dependency version in import paths and organize imports by sorting

### DIFF
--- a/contracts/AllowanceTarget.sol
+++ b/contracts/AllowanceTarget.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import { Pausable } from "@openzeppelin/contracts/utils/Pausable.sol";
+import { IERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/utils/SafeERC20.sol";
+import { Pausable } from "@openzeppelin/contracts@v5.0.2/utils/Pausable.sol";
 
 import { Ownable } from "./abstracts/Ownable.sol";
+
 import { IAllowanceTarget } from "./interfaces/IAllowanceTarget.sol";
 
 /// @title AllowanceTarget Contract
@@ -22,7 +23,7 @@ contract AllowanceTarget is IAllowanceTarget, Pausable, Ownable {
     /// @param trustedCaller An array of addresses that are initially authorized to call spendFromUserTo.
     constructor(address _owner, address[] memory trustedCaller) Ownable(_owner) {
         uint256 callerCount = trustedCaller.length;
-        for (uint256 i = 0; i < callerCount; ++i) {
+        for (uint256 i; i < callerCount; ++i) {
             authorized[trustedCaller[i]] = true;
         }
     }

--- a/contracts/CoordinatedTaker.sol
+++ b/contracts/CoordinatedTaker.sol
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import { TokenCollector } from "./abstracts/TokenCollector.sol";
 import { AdminManagement } from "./abstracts/AdminManagement.sol";
 import { EIP712 } from "./abstracts/EIP712.sol";
-import { IWETH } from "./interfaces/IWETH.sol";
+import { TokenCollector } from "./abstracts/TokenCollector.sol";
+
 import { ICoordinatedTaker } from "./interfaces/ICoordinatedTaker.sol";
 import { ILimitOrderSwap } from "./interfaces/ILimitOrderSwap.sol";
-import { LimitOrder, getLimitOrderHash } from "./libraries/LimitOrder.sol";
+import { IWETH } from "./interfaces/IWETH.sol";
+
 import { AllowFill, getAllowFillHash } from "./libraries/AllowFill.sol";
 import { Asset } from "./libraries/Asset.sol";
+import { LimitOrder, getLimitOrderHash } from "./libraries/LimitOrder.sol";
 import { SignatureValidator } from "./libraries/SignatureValidator.sol";
 
 /// @title CoordinatedTaker Contract

--- a/contracts/GenericSwap.sol
+++ b/contracts/GenericSwap.sol
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import { TokenCollector } from "./abstracts/TokenCollector.sol";
 import { EIP712 } from "./abstracts/EIP712.sol";
+import { TokenCollector } from "./abstracts/TokenCollector.sol";
+
 import { IGenericSwap } from "./interfaces/IGenericSwap.sol";
 import { IStrategy } from "./interfaces/IStrategy.sol";
-import { GenericSwapData, getGSDataHash } from "./libraries/GenericSwapData.sol";
+
 import { Asset } from "./libraries/Asset.sol";
+import { GenericSwapData, getGSDataHash } from "./libraries/GenericSwapData.sol";
 import { SignatureValidator } from "./libraries/SignatureValidator.sol";
 
 /// @title GenericSwap Contract

--- a/contracts/LimitOrderSwap.sol
+++ b/contracts/LimitOrderSwap.sol
@@ -1,17 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import { ReentrancyGuard } from "@openzeppelin/contracts@v5.0.2/utils/ReentrancyGuard.sol";
 
-import { TokenCollector } from "./abstracts/TokenCollector.sol";
-import { Ownable } from "./abstracts/Ownable.sol";
 import { EIP712 } from "./abstracts/EIP712.sol";
-import { IWETH } from "./interfaces/IWETH.sol";
+import { Ownable } from "./abstracts/Ownable.sol";
+import { TokenCollector } from "./abstracts/TokenCollector.sol";
+
 import { ILimitOrderSwap } from "./interfaces/ILimitOrderSwap.sol";
 import { IStrategy } from "./interfaces/IStrategy.sol";
+import { IWETH } from "./interfaces/IWETH.sol";
+
+import { Asset } from "./libraries/Asset.sol";
 import { Constant } from "./libraries/Constant.sol";
 import { LimitOrder, getLimitOrderHash } from "./libraries/LimitOrder.sol";
-import { Asset } from "./libraries/Asset.sol";
 import { SignatureValidator } from "./libraries/SignatureValidator.sol";
 
 /// @title LimitOrderSwap Contract
@@ -88,7 +90,7 @@ contract LimitOrderSwap is ILimitOrderSwap, Ownable, TokenCollector, EIP712, Ree
         uint256[] memory takerTokenAmounts = new uint256[](orders.length);
         uint256 wethToPay;
         address payable _feeCollector = feeCollector;
-        for (uint256 i = 0; i < orders.length; ++i) {
+        for (uint256 i; i < orders.length; ++i) {
             LimitOrder calldata order = orders[i];
             uint256 makingAmount = makerTokenAmounts[i];
             if (makingAmount == 0) revert ZeroMakerSpendingAmount();
@@ -133,13 +135,13 @@ contract LimitOrderSwap is ILimitOrderSwap, Ownable, TokenCollector, EIP712, Ree
             }
         }
 
-        for (uint256 i = 0; i < orders.length; ++i) {
+        for (uint256 i; i < orders.length; ++i) {
             LimitOrder calldata order = orders[i];
             order.takerToken.transferTo(order.maker, takerTokenAmounts[i]);
         }
 
         // any token left is considered as profit
-        for (uint256 i = 0; i < profitTokens.length; ++i) {
+        for (uint256 i; i < profitTokens.length; ++i) {
             uint256 profit = profitTokens[i].getBalance(address(this));
             profitTokens[i].transferTo(payable(msg.sender), profit);
         }

--- a/contracts/RFQ.sol
+++ b/contracts/RFQ.sol
@@ -1,17 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+import { Address } from "@openzeppelin/contracts@v5.0.2/utils/Address.sol";
 
-import { TokenCollector } from "./abstracts/TokenCollector.sol";
-import { Ownable } from "./abstracts/Ownable.sol";
 import { EIP712 } from "./abstracts/EIP712.sol";
-import { IWETH } from "./interfaces/IWETH.sol";
+import { Ownable } from "./abstracts/Ownable.sol";
+import { TokenCollector } from "./abstracts/TokenCollector.sol";
+
 import { IRFQ } from "./interfaces/IRFQ.sol";
+import { IWETH } from "./interfaces/IWETH.sol";
 import { Asset } from "./libraries/Asset.sol";
+
+import { Constant } from "./libraries/Constant.sol";
 import { RFQOffer, getRFQOfferHash } from "./libraries/RFQOffer.sol";
 import { RFQTx, getRFQTxHash } from "./libraries/RFQTx.sol";
-import { Constant } from "./libraries/Constant.sol";
 import { SignatureValidator } from "./libraries/SignatureValidator.sol";
 
 /// @title RFQ Contract

--- a/contracts/SmartOrderStrategy.sol
+++ b/contracts/SmartOrderStrategy.sol
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/IERC20.sol";
 
 import { AdminManagement } from "./abstracts/AdminManagement.sol";
-import { Asset } from "./libraries/Asset.sol";
-import { IWETH } from "./interfaces/IWETH.sol";
+
 import { ISmartOrderStrategy } from "./interfaces/ISmartOrderStrategy.sol";
 import { IStrategy } from "./interfaces/IStrategy.sol";
+import { IWETH } from "./interfaces/IWETH.sol";
+
+import { Asset } from "./libraries/Asset.sol";
 
 /// @title SmartOrderStrategy Contract
 /// @author imToken Labs
@@ -52,7 +54,7 @@ contract SmartOrderStrategy is ISmartOrderStrategy, AdminManagement {
         }
 
         uint256 opsCount = ops.length;
-        for (uint256 i = 0; i < opsCount; ++i) {
+        for (uint256 i; i < opsCount; ++i) {
             Operation memory op = ops[i];
             _call(op.dest, op.inputToken, op.ratioNumerator, op.ratioDenominator, op.dataOffset, op.value, op.data);
         }

--- a/contracts/abstracts/AdminManagement.sol
+++ b/contracts/abstracts/AdminManagement.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/utils/SafeERC20.sol";
+
+import { Asset } from "../libraries/Asset.sol";
 
 import { Ownable } from "./Ownable.sol";
-import { Asset } from "../libraries/Asset.sol";
 
 /// @title AdminManagement Contract
 /// @author imToken Labs
@@ -22,8 +23,8 @@ abstract contract AdminManagement is Ownable {
     /// @param tokens The array of token addresses to approve.
     /// @param spenders The array of spender addresses to approve for each token.
     function approveTokens(address[] calldata tokens, address[] calldata spenders) external onlyOwner {
-        for (uint256 i = 0; i < tokens.length; ++i) {
-            for (uint256 j = 0; j < spenders.length; ++j) {
+        for (uint256 i; i < tokens.length; ++i) {
+            for (uint256 j; j < spenders.length; ++j) {
                 IERC20(tokens[i]).forceApprove(spenders[j], type(uint256).max);
             }
         }
@@ -34,7 +35,7 @@ abstract contract AdminManagement is Ownable {
     /// @param tokens An array of token addresses to rescue.
     /// @param recipient The address to which rescued tokens will be transferred.
     function rescueTokens(address[] calldata tokens, address recipient) external onlyOwner {
-        for (uint256 i = 0; i < tokens.length; ++i) {
+        for (uint256 i; i < tokens.length; ++i) {
             uint256 selfBalance = Asset.getBalance(tokens[i], address(this));
             Asset.transferTo(tokens[i], payable(recipient), selfBalance);
         }

--- a/contracts/abstracts/TokenCollector.sol
+++ b/contracts/abstracts/TokenCollector.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import { IERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/IERC20.sol";
+import { IERC20Permit } from "@openzeppelin/contracts@v5.0.2/token/ERC20/extensions/IERC20Permit.sol";
+import { SafeERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/utils/SafeERC20.sol";
 
-import { IUniswapPermit2 } from "../interfaces/IUniswapPermit2.sol";
 import { IAllowanceTarget } from "../interfaces/IAllowanceTarget.sol";
+import { IUniswapPermit2 } from "../interfaces/IUniswapPermit2.sol";
 
 /// @title TokenCollector Contract
 /// @author imToken Labs

--- a/contracts/interfaces/ICoordinatedTaker.sol
+++ b/contracts/interfaces/ICoordinatedTaker.sol
@@ -6,6 +6,24 @@ import { LimitOrder } from "../libraries/LimitOrder.sol";
 /// @title ICoordinatedTaker Interface
 /// @author imToken Labs
 interface ICoordinatedTaker {
+    /// @title Coordinator Parameters
+    /// @dev Contains the signature, salt, and expiry for coordinator authorization.
+    struct CoordinatorParams {
+        bytes sig;
+        uint256 salt;
+        uint256 expiry;
+    }
+
+    /// @notice Emitted when a limit order is filled by the coordinator.
+    /// @param user The address of the user.
+    /// @param orderHash The hash of the order.
+    /// @param allowFillHash The hash of the allowed fill.
+    event CoordinatorFill(address indexed user, bytes32 indexed orderHash, bytes32 indexed allowFillHash);
+
+    /// @notice Emitted when the coordinator address is updated.
+    /// @param newCoordinator The address of the new coordinator.
+    event SetCoordinator(address newCoordinator);
+
     /// @notice Error to be thrown when a permission is reused.
     /// @dev This error is used to prevent the reuse of permissions.
     error ReusedPermission();
@@ -25,24 +43,6 @@ interface ICoordinatedTaker {
     /// @notice Error to be thrown when an address is zero.
     /// @dev This error is used to ensure that a valid address is provided.
     error ZeroAddress();
-
-    /// @title Coordinator Parameters
-    /// @dev Contains the signature, salt, and expiry for coordinator authorization.
-    struct CoordinatorParams {
-        bytes sig;
-        uint256 salt;
-        uint256 expiry;
-    }
-
-    /// @notice Emitted when a limit order is filled by the coordinator.
-    /// @param user The address of the user.
-    /// @param orderHash The hash of the order.
-    /// @param allowFillHash The hash of the allowed fill.
-    event CoordinatorFill(address indexed user, bytes32 indexed orderHash, bytes32 indexed allowFillHash);
-
-    /// @notice Emitted when the coordinator address is updated.
-    /// @param newCoordinator The address of the new coordinator.
-    event SetCoordinator(address newCoordinator);
 
     /// @notice Submits a limit order fill with additional coordination parameters..
     /// @param order The limit order to be filled.

--- a/contracts/libraries/Asset.sol
+++ b/contracts/libraries/Asset.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/utils/SafeERC20.sol";
 
 import { Constant } from "./Constant.sol";
 

--- a/contracts/libraries/RFQTx.sol
+++ b/contracts/libraries/RFQTx.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { RFQOffer, getRFQOfferHash, RFQ_OFFER_TYPESTRING } from "./RFQOffer.sol";
+import { RFQOffer, RFQ_OFFER_TYPESTRING, getRFQOfferHash } from "./RFQOffer.sol";
 
 string constant RFQ_TX_TYPESTRING = string(abi.encodePacked("RFQTx(RFQOffer rfqOffer,address recipient,uint256 takerRequestAmount)", RFQ_OFFER_TYPESTRING));
 

--- a/contracts/libraries/SignatureValidator.sol
+++ b/contracts/libraries/SignatureValidator.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+import { Address } from "@openzeppelin/contracts@v5.0.2/utils/Address.sol";
+import { ECDSA } from "@openzeppelin/contracts@v5.0.2/utils/cryptography/ECDSA.sol";
 
 import { IERC1271Wallet } from "../interfaces/IERC1271Wallet.sol";
 

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,2 +1,2 @@
-@openzeppelin/=lib/openzeppelin-contracts/
+@openzeppelin/contracts@v5.0.2=lib/openzeppelin-contracts/contracts/
 forge-std/=lib/forge-std/src

--- a/test/AllowanceTarget.t.sol
+++ b/test/AllowanceTarget.t.sol
@@ -1,15 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import { Pausable } from "@openzeppelin/contracts/utils/Pausable.sol";
+import { IERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/utils/SafeERC20.sol";
+import { Pausable } from "@openzeppelin/contracts@v5.0.2/utils/Pausable.sol";
 
-import { IAllowanceTarget } from "contracts/interfaces/IAllowanceTarget.sol";
 import { AllowanceTarget } from "contracts/AllowanceTarget.sol";
 import { Ownable } from "contracts/abstracts/Ownable.sol";
-import { MockERC20 } from "test/mocks/MockERC20.sol";
+import { IAllowanceTarget } from "contracts/interfaces/IAllowanceTarget.sol";
+
 import { MockDeflationaryERC20 } from "test/mocks/MockDeflationaryERC20.sol";
+import { MockERC20 } from "test/mocks/MockERC20.sol";
 import { MockNoReturnERC20 } from "test/mocks/MockNoReturnERC20.sol";
 import { MockNoRevertERC20 } from "test/mocks/MockNoRevertERC20.sol";
 import { BalanceSnapshot, Snapshot } from "test/utils/BalanceSnapshot.sol";

--- a/test/Signing.t.sol
+++ b/test/Signing.t.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import { AllowFill, ALLOWFILL_DATA_TYPEHASH } from "contracts/libraries/AllowFill.sol";
-import { GenericSwapData, GS_DATA_TYPEHASH } from "contracts/libraries/GenericSwapData.sol";
-import { LimitOrder, LIMITORDER_DATA_TYPEHASH } from "contracts/libraries/LimitOrder.sol";
+import { ALLOWFILL_DATA_TYPEHASH, AllowFill } from "contracts/libraries/AllowFill.sol";
+import { GS_DATA_TYPEHASH, GenericSwapData } from "contracts/libraries/GenericSwapData.sol";
+import { LIMITORDER_DATA_TYPEHASH, LimitOrder } from "contracts/libraries/LimitOrder.sol";
 import { RFQOffer, RFQ_OFFER_DATA_TYPEHASH } from "contracts/libraries/RFQOffer.sol";
 import { RFQTx, RFQ_TX_TYPEHASH } from "contracts/libraries/RFQTx.sol";
+
 import { SigHelper } from "test/utils/SigHelper.sol";
 
 contract testEIP712Signing is SigHelper {

--- a/test/abstracts/AdminManagement.t.sol
+++ b/test/abstracts/AdminManagement.t.sol
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/IERC20.sol";
 
 import { AdminManagement } from "contracts/abstracts/AdminManagement.sol";
 import { Ownable } from "contracts/abstracts/Ownable.sol";
+
 import { MockERC20 } from "test/mocks/MockERC20.sol";
 import { BalanceUtil } from "test/utils/BalanceUtil.sol";
 

--- a/test/abstracts/EIP712.t.sol
+++ b/test/abstracts/EIP712.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.26;
 
 import { Test } from "forge-std/Test.sol";
+
 import { EIP712 } from "contracts/abstracts/EIP712.sol";
 
 contract EIP712Test is Test {

--- a/test/abstracts/Ownable.t.sol
+++ b/test/abstracts/Ownable.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.26;
 
 import { Test } from "forge-std/Test.sol";
+
 import { Ownable } from "contracts/abstracts/Ownable.sol";
 
 contract OwnableTest is Test {

--- a/test/forkMainnet/GenericSwap.t.sol
+++ b/test/forkMainnet/GenericSwap.t.sol
@@ -2,23 +2,25 @@
 pragma solidity 0.8.26;
 
 import { Test } from "forge-std/Test.sol";
-import { Tokens } from "test/utils/Tokens.sol";
-import { BalanceUtil } from "test/utils/BalanceUtil.sol";
-import { SigHelper } from "test/utils/SigHelper.sol";
-import { BalanceSnapshot, Snapshot } from "test/utils/BalanceSnapshot.sol";
-import { computeContractAddress } from "test/utils/Addresses.sol";
-import { Permit2Helper } from "test/utils/Permit2Helper.sol";
-import { UniswapV3 } from "test/utils/UniswapV3.sol";
-import { IUniswapV3Quoter } from "test/utils/IUniswapV3Quoter.sol";
-import { IUniswapSwapRouter02 } from "test/utils/IUniswapSwapRouter02.sol";
-import { MockStrategy } from "test/mocks/MockStrategy.sol";
-import { GenericSwap } from "contracts/GenericSwap.sol";
+
 import { AllowanceTarget } from "contracts/AllowanceTarget.sol";
+import { GenericSwap } from "contracts/GenericSwap.sol";
 import { SmartOrderStrategy } from "contracts/SmartOrderStrategy.sol";
-import { Constant } from "contracts/libraries/Constant.sol";
-import { GenericSwapData, getGSDataHash } from "contracts/libraries/GenericSwapData.sol";
 import { IGenericSwap } from "contracts/interfaces/IGenericSwap.sol";
 import { ISmartOrderStrategy } from "contracts/interfaces/ISmartOrderStrategy.sol";
+import { Constant } from "contracts/libraries/Constant.sol";
+import { GenericSwapData, getGSDataHash } from "contracts/libraries/GenericSwapData.sol";
+
+import { MockStrategy } from "test/mocks/MockStrategy.sol";
+import { computeContractAddress } from "test/utils/Addresses.sol";
+import { BalanceSnapshot, Snapshot } from "test/utils/BalanceSnapshot.sol";
+import { BalanceUtil } from "test/utils/BalanceUtil.sol";
+import { IUniswapSwapRouter02 } from "test/utils/IUniswapSwapRouter02.sol";
+import { IUniswapV3Quoter } from "test/utils/IUniswapV3Quoter.sol";
+import { Permit2Helper } from "test/utils/Permit2Helper.sol";
+import { SigHelper } from "test/utils/SigHelper.sol";
+import { Tokens } from "test/utils/Tokens.sol";
+import { UniswapV3 } from "test/utils/UniswapV3.sol";
 
 contract GenericSwapTest is Test, Tokens, BalanceUtil, Permit2Helper, SigHelper {
     using BalanceSnapshot for Snapshot;

--- a/test/forkMainnet/LimitOrderSwap/CancelOrder.t.sol
+++ b/test/forkMainnet/LimitOrderSwap/CancelOrder.t.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import { getLimitOrderHash } from "contracts/libraries/LimitOrder.sol";
 import { ILimitOrderSwap } from "contracts/interfaces/ILimitOrderSwap.sol";
+import { getLimitOrderHash } from "contracts/libraries/LimitOrder.sol";
+
 import { LimitOrderSwapTest } from "test/forkMainnet/LimitOrderSwap/Setup.t.sol";
 
 contract CancelOrderTest is LimitOrderSwapTest {

--- a/test/forkMainnet/LimitOrderSwap/CoordinatedTaker.t.sol
+++ b/test/forkMainnet/LimitOrderSwap/CoordinatedTaker.t.sol
@@ -1,17 +1,18 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import { ILimitOrderSwap } from "contracts/interfaces/ILimitOrderSwap.sol";
-import { ICoordinatedTaker } from "contracts/interfaces/ICoordinatedTaker.sol";
-import { IWETH } from "contracts/interfaces/IWETH.sol";
-import { Constant } from "contracts/libraries/Constant.sol";
-import { LimitOrder, getLimitOrderHash } from "contracts/libraries/LimitOrder.sol";
-import { AllowFill, getAllowFillHash } from "contracts/libraries/AllowFill.sol";
 import { CoordinatedTaker } from "contracts/CoordinatedTaker.sol";
 import { Ownable } from "contracts/abstracts/Ownable.sol";
-import { BalanceSnapshot, Snapshot } from "test/utils/BalanceSnapshot.sol";
+import { ICoordinatedTaker } from "contracts/interfaces/ICoordinatedTaker.sol";
+import { ILimitOrderSwap } from "contracts/interfaces/ILimitOrderSwap.sol";
+import { IWETH } from "contracts/interfaces/IWETH.sol";
+import { AllowFill, getAllowFillHash } from "contracts/libraries/AllowFill.sol";
+import { Constant } from "contracts/libraries/Constant.sol";
+import { LimitOrder, getLimitOrderHash } from "contracts/libraries/LimitOrder.sol";
+
 import { LimitOrderSwapTest } from "test/forkMainnet/LimitOrderSwap/Setup.t.sol";
 import { MockERC20 } from "test/mocks/MockERC20.sol";
+import { BalanceSnapshot, Snapshot } from "test/utils/BalanceSnapshot.sol";
 
 contract CoordinatedTakerTest is LimitOrderSwapTest {
     using BalanceSnapshot for Snapshot;

--- a/test/forkMainnet/LimitOrderSwap/Fill.t.sol
+++ b/test/forkMainnet/LimitOrderSwap/Fill.t.sol
@@ -1,17 +1,18 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+import { IERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/utils/SafeERC20.sol";
+import { Address } from "@openzeppelin/contracts@v5.0.2/utils/Address.sol";
 
 import { ILimitOrderSwap } from "contracts/interfaces/ILimitOrderSwap.sol";
 import { Constant } from "contracts/libraries/Constant.sol";
 import { LimitOrder, getLimitOrderHash } from "contracts/libraries/LimitOrder.sol";
-import { BalanceSnapshot, Snapshot } from "test/utils/BalanceSnapshot.sol";
-import { UniswapV2Library } from "test/utils/UniswapV2Library.sol";
+
 import { LimitOrderSwapTest } from "test/forkMainnet/LimitOrderSwap/Setup.t.sol";
 import { MockStrategy } from "test/mocks/MockStrategy.sol";
+import { BalanceSnapshot, Snapshot } from "test/utils/BalanceSnapshot.sol";
+import { UniswapV2Library } from "test/utils/UniswapV2Library.sol";
 
 contract FillTest is LimitOrderSwapTest {
     using BalanceSnapshot for Snapshot;

--- a/test/forkMainnet/LimitOrderSwap/FullOrKill.t.sol
+++ b/test/forkMainnet/LimitOrderSwap/FullOrKill.t.sol
@@ -4,8 +4,9 @@ pragma solidity 0.8.26;
 import { ILimitOrderSwap } from "contracts/interfaces/ILimitOrderSwap.sol";
 import { Constant } from "contracts/libraries/Constant.sol";
 import { getLimitOrderHash } from "contracts/libraries/LimitOrder.sol";
-import { BalanceSnapshot, Snapshot } from "test/utils/BalanceSnapshot.sol";
+
 import { LimitOrderSwapTest } from "test/forkMainnet/LimitOrderSwap/Setup.t.sol";
+import { BalanceSnapshot, Snapshot } from "test/utils/BalanceSnapshot.sol";
 
 contract FullOrKillTest is LimitOrderSwapTest {
     using BalanceSnapshot for Snapshot;

--- a/test/forkMainnet/LimitOrderSwap/GroupFill.t.sol
+++ b/test/forkMainnet/LimitOrderSwap/GroupFill.t.sol
@@ -2,10 +2,11 @@
 pragma solidity 0.8.26;
 
 import { IUniswapPermit2 } from "contracts/interfaces/IUniswapPermit2.sol";
-import { LimitOrder, getLimitOrderHash } from "contracts/libraries/LimitOrder.sol";
 import { Constant } from "contracts/libraries/Constant.sol";
-import { BalanceSnapshot, Snapshot } from "test/utils/BalanceSnapshot.sol";
+import { LimitOrder, getLimitOrderHash } from "contracts/libraries/LimitOrder.sol";
+
 import { LimitOrderSwapTest } from "test/forkMainnet/LimitOrderSwap/Setup.t.sol";
+import { BalanceSnapshot, Snapshot } from "test/utils/BalanceSnapshot.sol";
 
 contract GroupFillTest is LimitOrderSwapTest {
     using BalanceSnapshot for Snapshot;
@@ -18,7 +19,7 @@ contract GroupFillTest is LimitOrderSwapTest {
         super.setUp();
 
         deal(arbitrageur, 100 ether);
-        for (uint256 i = 0; i < makerPrivateKeys.length; ++i) {
+        for (uint256 i; i < makerPrivateKeys.length; ++i) {
             makers[i] = payable(vm.addr(makerPrivateKeys[i]));
             deal(makers[i], 100 ether);
             setTokenBalanceAndApprove(makers[i], UNISWAP_PERMIT2_ADDRESS, tokens, 100000);

--- a/test/forkMainnet/LimitOrderSwap/Management.t.sol
+++ b/test/forkMainnet/LimitOrderSwap/Management.t.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import { ILimitOrderSwap } from "contracts/interfaces/ILimitOrderSwap.sol";
 import { Ownable } from "contracts/abstracts/Ownable.sol";
+import { ILimitOrderSwap } from "contracts/interfaces/ILimitOrderSwap.sol";
+
 import { LimitOrderSwapTest } from "test/forkMainnet/LimitOrderSwap/Setup.t.sol";
 
 contract ManagementTest is LimitOrderSwapTest {

--- a/test/forkMainnet/LimitOrderSwap/Setup.t.sol
+++ b/test/forkMainnet/LimitOrderSwap/Setup.t.sol
@@ -2,19 +2,21 @@
 pragma solidity 0.8.26;
 
 import { Test } from "forge-std/Test.sol";
-import { Tokens } from "test/utils/Tokens.sol";
-import { BalanceUtil } from "test/utils/BalanceUtil.sol";
-import { SigHelper } from "test/utils/SigHelper.sol";
-import { computeContractAddress } from "test/utils/Addresses.sol";
-import { Permit2Helper } from "test/utils/Permit2Helper.sol";
-import { MockLimitOrderTaker } from "test/mocks/MockLimitOrderTaker.sol";
-import { LimitOrderSwap } from "contracts/LimitOrderSwap.sol";
+
 import { AllowanceTarget } from "contracts/AllowanceTarget.sol";
-import { IWETH } from "contracts/interfaces/IWETH.sol";
+import { LimitOrderSwap } from "contracts/LimitOrderSwap.sol";
+import { TokenCollector } from "contracts/abstracts/TokenCollector.sol";
 import { ILimitOrderSwap } from "contracts/interfaces/ILimitOrderSwap.sol";
 import { IUniswapPermit2 } from "contracts/interfaces/IUniswapPermit2.sol";
-import { TokenCollector } from "contracts/abstracts/TokenCollector.sol";
-import { LimitOrder, getLimitOrderHash } from "contracts/libraries/LimitOrder.sol";
+import { IWETH } from "contracts/interfaces/IWETH.sol";
+import { LimitOrder } from "contracts/libraries/LimitOrder.sol";
+
+import { MockLimitOrderTaker } from "test/mocks/MockLimitOrderTaker.sol";
+import { computeContractAddress } from "test/utils/Addresses.sol";
+import { BalanceUtil } from "test/utils/BalanceUtil.sol";
+import { Permit2Helper } from "test/utils/Permit2Helper.sol";
+import { SigHelper } from "test/utils/SigHelper.sol";
+import { Tokens } from "test/utils/Tokens.sol";
 
 contract LimitOrderSwapTest is Test, Tokens, BalanceUtil, Permit2Helper, SigHelper {
     event SetFeeCollector(address newFeeCollector);

--- a/test/forkMainnet/LimitOrderSwap/Validation.t.sol
+++ b/test/forkMainnet/LimitOrderSwap/Validation.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.26;
 
 import { LimitOrderSwapTest } from "./Setup.t.sol";
+
 import { ILimitOrderSwap } from "contracts/interfaces/ILimitOrderSwap.sol";
 import { LimitOrder } from "contracts/libraries/LimitOrder.sol";
 

--- a/test/forkMainnet/RFQ.t.sol
+++ b/test/forkMainnet/RFQ.t.sol
@@ -2,22 +2,24 @@
 pragma solidity 0.8.26;
 
 import { Test } from "forge-std/Test.sol";
-import { Tokens } from "test/utils/Tokens.sol";
-import { BalanceUtil } from "test/utils/BalanceUtil.sol";
-import { BalanceSnapshot, Snapshot } from "test/utils/BalanceSnapshot.sol";
-import { MockERC1271Wallet } from "test/mocks/MockERC1271Wallet.sol";
-import { computeContractAddress } from "test/utils/Addresses.sol";
-import { Permit2Helper } from "test/utils/Permit2Helper.sol";
-import { SigHelper } from "test/utils/SigHelper.sol";
+
+import { AllowanceTarget } from "contracts/AllowanceTarget.sol";
 import { RFQ } from "contracts/RFQ.sol";
 import { Ownable } from "contracts/abstracts/Ownable.sol";
-import { AllowanceTarget } from "contracts/AllowanceTarget.sol";
+import { TokenCollector } from "contracts/abstracts/TokenCollector.sol";
 import { IRFQ } from "contracts/interfaces/IRFQ.sol";
 import { IWETH } from "contracts/interfaces/IWETH.sol";
-import { TokenCollector } from "contracts/abstracts/TokenCollector.sol";
+import { Constant } from "contracts/libraries/Constant.sol";
 import { RFQOffer, getRFQOfferHash } from "contracts/libraries/RFQOffer.sol";
 import { RFQTx } from "contracts/libraries/RFQTx.sol";
-import { Constant } from "contracts/libraries/Constant.sol";
+
+import { MockERC1271Wallet } from "test/mocks/MockERC1271Wallet.sol";
+import { computeContractAddress } from "test/utils/Addresses.sol";
+import { BalanceSnapshot, Snapshot } from "test/utils/BalanceSnapshot.sol";
+import { BalanceUtil } from "test/utils/BalanceUtil.sol";
+import { Permit2Helper } from "test/utils/Permit2Helper.sol";
+import { SigHelper } from "test/utils/SigHelper.sol";
+import { Tokens } from "test/utils/Tokens.sol";
 
 contract RFQTest is Test, Tokens, BalanceUtil, Permit2Helper, SigHelper {
     using BalanceSnapshot for Snapshot;

--- a/test/forkMainnet/SmartOrderStrategy/AMMs.t.sol
+++ b/test/forkMainnet/SmartOrderStrategy/AMMs.t.sol
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/utils/SafeERC20.sol";
 
 import { SmartOrderStrategyTest } from "./Setup.t.sol";
-import { ICurveFiV2 } from "test/utils/ICurveFiV2.sol";
+
 import { ISmartOrderStrategy } from "contracts/interfaces/ISmartOrderStrategy.sol";
-import { IUniswapSwapRouter02 } from "test/utils/IUniswapSwapRouter02.sol";
 import { Constant } from "contracts/libraries/Constant.sol";
+
 import { BalanceSnapshot, Snapshot } from "test/utils/BalanceSnapshot.sol";
+import { ICurveFiV2 } from "test/utils/ICurveFiV2.sol";
+import { IUniswapSwapRouter02 } from "test/utils/IUniswapSwapRouter02.sol";
 
 contract AMMsTest is SmartOrderStrategyTest {
     using SafeERC20 for IERC20;

--- a/test/forkMainnet/SmartOrderStrategy/IntegrationV6.t.sol
+++ b/test/forkMainnet/SmartOrderStrategy/IntegrationV6.t.sol
@@ -1,21 +1,23 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/utils/SafeERC20.sol";
 
 import { SmartOrderStrategyTest } from "./Setup.t.sol";
+
+import { LimitOrderSwap } from "contracts/LimitOrderSwap.sol";
 import { LimitOrderSwap } from "contracts/LimitOrderSwap.sol";
 import { RFQ } from "contracts/RFQ.sol";
-import { LimitOrderSwap } from "contracts/LimitOrderSwap.sol";
-import { IWETH } from "contracts/interfaces/IWETH.sol";
-import { ISmartOrderStrategy } from "contracts/interfaces/ISmartOrderStrategy.sol";
-import { ILimitOrderSwap } from "contracts/interfaces/ILimitOrderSwap.sol";
 import { TokenCollector } from "contracts/abstracts/TokenCollector.sol";
+import { ILimitOrderSwap } from "contracts/interfaces/ILimitOrderSwap.sol";
+import { ISmartOrderStrategy } from "contracts/interfaces/ISmartOrderStrategy.sol";
+import { IWETH } from "contracts/interfaces/IWETH.sol";
 import { Constant } from "contracts/libraries/Constant.sol";
+import { LimitOrder } from "contracts/libraries/LimitOrder.sol";
 import { RFQOffer } from "contracts/libraries/RFQOffer.sol";
 import { RFQTx } from "contracts/libraries/RFQTx.sol";
-import { LimitOrder } from "contracts/libraries/LimitOrder.sol";
+
 import { BalanceSnapshot, Snapshot } from "test/utils/BalanceSnapshot.sol";
 import { SigHelper } from "test/utils/SigHelper.sol";
 

--- a/test/forkMainnet/SmartOrderStrategy/Setup.t.sol
+++ b/test/forkMainnet/SmartOrderStrategy/Setup.t.sol
@@ -2,10 +2,12 @@
 pragma solidity 0.8.26;
 
 import { Test } from "forge-std/Test.sol";
+
 import { SmartOrderStrategy } from "contracts/SmartOrderStrategy.sol";
-import { Tokens } from "test/utils/Tokens.sol";
+
 import { BalanceUtil } from "test/utils/BalanceUtil.sol";
 import { IUniswapV3Quoter } from "test/utils/IUniswapV3Quoter.sol";
+import { Tokens } from "test/utils/Tokens.sol";
 import { UniswapV3 } from "test/utils/UniswapV3.sol";
 
 contract SmartOrderStrategyTest is Test, Tokens, BalanceUtil {
@@ -37,7 +39,7 @@ contract SmartOrderStrategyTest is Test, Tokens, BalanceUtil {
 
         // Make genericSwap rich to provide fund for strategy contract
         deal(genericSwap, 100 ether);
-        for (uint256 i = 0; i < tokenList.length; i++) {
+        for (uint256 i; i < tokenList.length; i++) {
             setERC20Balance(tokenList[i], genericSwap, 10000);
         }
 

--- a/test/forkMainnet/SmartOrderStrategy/Validation.t.sol
+++ b/test/forkMainnet/SmartOrderStrategy/Validation.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.26;
 
 import { SmartOrderStrategyTest } from "./Setup.t.sol";
+
 import { ISmartOrderStrategy } from "contracts/interfaces/ISmartOrderStrategy.sol";
 import { Constant } from "contracts/libraries/Constant.sol";
 

--- a/test/forkMainnet/TokenCollector.t.sol
+++ b/test/forkMainnet/TokenCollector.t.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import { ERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
-import { IERC20Errors } from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
-import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import { IERC20Errors } from "@openzeppelin/contracts@v5.0.2/interfaces/draft-IERC6093.sol";
+import { ERC20Permit } from "@openzeppelin/contracts@v5.0.2/token/ERC20/extensions/ERC20Permit.sol";
+import { ECDSA } from "@openzeppelin/contracts@v5.0.2/utils/cryptography/ECDSA.sol";
 
 import { AllowanceTarget } from "contracts/AllowanceTarget.sol";
 import { TokenCollector } from "contracts/abstracts/TokenCollector.sol";
 import { IUniswapPermit2 } from "contracts/interfaces/IUniswapPermit2.sol";
+
 import { MockERC20Permit } from "test/mocks/MockERC20Permit.sol";
 import { Addresses, computeContractAddress } from "test/utils/Addresses.sol";
 import { Permit2Helper } from "test/utils/Permit2Helper.sol";

--- a/test/libraries/Asset.t.sol
+++ b/test/libraries/Asset.t.sol
@@ -2,8 +2,10 @@
 pragma solidity 0.8.26;
 
 import { Test } from "forge-std/Test.sol";
+
 import { Asset } from "contracts/libraries/Asset.sol";
 import { Constant } from "contracts/libraries/Constant.sol";
+
 import { MockERC20 } from "test/mocks/MockERC20.sol";
 
 contract AssetTest is Test {

--- a/test/libraries/SignatureValidator.t.sol
+++ b/test/libraries/SignatureValidator.t.sol
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
+import { ECDSA } from "@openzeppelin/contracts@v5.0.2/utils/cryptography/ECDSA.sol";
 import { Test } from "forge-std/Test.sol";
+
 import { IERC1271Wallet } from "contracts/interfaces/IERC1271Wallet.sol";
 import { SignatureValidator } from "contracts/libraries/SignatureValidator.sol";
+
 import { MockERC1271Wallet } from "test/mocks/MockERC1271Wallet.sol";
-import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 contract SignatureValidatorTest is Test {
     uint256 userPrivateKey = 1234;

--- a/test/mocks/MockDeflationaryERC20.sol
+++ b/test/mocks/MockDeflationaryERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/IERC20.sol";
 
 /**
  * @dev Burn a portion of tokens while transferring. (STA)

--- a/test/mocks/MockERC1271Wallet.sol
+++ b/test/mocks/MockERC1271Wallet.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import { IERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/utils/SafeERC20.sol";
+import { ECDSA } from "@openzeppelin/contracts@v5.0.2/utils/cryptography/ECDSA.sol";
 
 import { IERC1271Wallet } from "contracts/interfaces/IERC1271Wallet.sol";
 
@@ -28,13 +28,13 @@ contract MockERC1271Wallet is IERC1271Wallet {
     receive() external payable {}
 
     function setAllowance(address[] memory _tokenList, address _spender) external onlyOperator {
-        for (uint256 i = 0; i < _tokenList.length; i++) {
+        for (uint256 i; i < _tokenList.length; i++) {
             IERC20(_tokenList[i]).forceApprove(_spender, MAX_UINT);
         }
     }
 
     function closeAllowance(address[] memory _tokenList, address _spender) external onlyOperator {
-        for (uint256 i = 0; i < _tokenList.length; i++) {
+        for (uint256 i; i < _tokenList.length; i++) {
             IERC20(_tokenList[i]).forceApprove(_spender, 0);
         }
     }

--- a/test/mocks/MockERC20.sol
+++ b/test/mocks/MockERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { ERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/ERC20.sol";
 
 contract MockERC20 is ERC20 {
     uint8 private underlyingDecimals;

--- a/test/mocks/MockERC20Permit.sol
+++ b/test/mocks/MockERC20Permit.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import { ERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
+import { ERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/ERC20.sol";
+import { ERC20Permit } from "@openzeppelin/contracts@v5.0.2/token/ERC20/extensions/ERC20Permit.sol";
 
 import { MockERC20 } from "./MockERC20.sol";
 

--- a/test/mocks/MockLimitOrderTaker.sol
+++ b/test/mocks/MockLimitOrderTaker.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/utils/SafeERC20.sol";
 
-import { Ownable } from "contracts/abstracts/Ownable.sol";
-import { IStrategy } from "contracts/interfaces/IStrategy.sol";
-import { IUniswapSwapRouter02 } from "test/utils/IUniswapSwapRouter02.sol";
 import { MockERC1271Wallet } from "./MockERC1271Wallet.sol";
+
+import { IStrategy } from "contracts/interfaces/IStrategy.sol";
+
+import { IUniswapSwapRouter02 } from "test/utils/IUniswapSwapRouter02.sol";
 
 contract MockLimitOrderTaker is IStrategy, MockERC1271Wallet {
     using SafeERC20 for IERC20;

--- a/test/mocks/MockStrategy.sol
+++ b/test/mocks/MockStrategy.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { Asset } from "contracts/libraries/Asset.sol";
 import { IStrategy } from "contracts/interfaces/IStrategy.sol";
+import { Asset } from "contracts/libraries/Asset.sol";
 
 contract MockStrategy is IStrategy {
     using Asset for address;

--- a/test/utils/BalanceSnapshot.sol
+++ b/test/utils/BalanceSnapshot.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/IERC20.sol";
+
 import { Constant } from "contracts/libraries/Constant.sol";
 
 struct Snapshot {

--- a/test/utils/BalanceUtil.sol
+++ b/test/utils/BalanceUtil.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import { ERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/ERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/utils/SafeERC20.sol";
 import { StdStorage, stdStorage } from "forge-std/StdStorage.sol";
 import { Test } from "forge-std/Test.sol";
-import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 contract BalanceUtil is Test {
     using stdStorage for StdStorage;
@@ -16,7 +16,7 @@ contract BalanceUtil is Test {
     }
 
     function setTokenBalanceAndApprove(address user, address spender, IERC20[] memory tokens, uint256 amount) internal {
-        for (uint256 i = 0; i < tokens.length; i++) {
+        for (uint256 i; i < tokens.length; i++) {
             setERC20Balance(address(tokens[i]), user, amount);
             approveERC20(address(tokens[i]), user, spender);
         }

--- a/test/utils/Permit2Helper.sol
+++ b/test/utils/Permit2Helper.sol
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import { IUniswapPermit2 } from "contracts/interfaces/IUniswapPermit2.sol";
-import { TokenCollector } from "contracts/abstracts/TokenCollector.sol";
-import { getEIP712Hash } from "test/utils/Sig.sol";
 import { Test } from "forge-std/Test.sol";
+
+import { TokenCollector } from "contracts/abstracts/TokenCollector.sol";
+import { IUniswapPermit2 } from "contracts/interfaces/IUniswapPermit2.sol";
+
+import { getEIP712Hash } from "test/utils/Sig.sol";
 
 contract Permit2Helper is Test {
     IUniswapPermit2 public constant permit2 = IUniswapPermit2(0x000000000022D473030F116dDEE9F6B43aC78BA3);

--- a/test/utils/SigHelper.sol
+++ b/test/utils/SigHelper.sol
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
+import { Test } from "forge-std/Test.sol";
+
 import { AllowFill, getAllowFillHash } from "contracts/libraries/AllowFill.sol";
 import { GenericSwapData, getGSDataHash } from "contracts/libraries/GenericSwapData.sol";
 import { LimitOrder, getLimitOrderHash } from "contracts/libraries/LimitOrder.sol";
 import { RFQOffer, getRFQOfferHash } from "contracts/libraries/RFQOffer.sol";
 import { RFQTx, getRFQTxHash } from "contracts/libraries/RFQTx.sol";
-import { Test } from "forge-std/Test.sol";
 
 contract SigHelper is Test {
     function getEIP712Hash(bytes32 domainSeparator, bytes32 structHash) internal pure returns (bytes32) {

--- a/test/utils/Tokens.sol
+++ b/test/utils/Tokens.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts@v5.0.2/token/ERC20/IERC20.sol";
+
 import { MockERC20 } from "test/mocks/MockERC20.sol";
 import { MockWETH } from "test/mocks/MockWETH.sol";
 import { Addresses } from "test/utils/Addresses.sol";

--- a/test/utils/UniswapV3.sol
+++ b/test/utils/UniswapV3.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import { IUniswapV3SwapRouter } from "./IUniswapV3SwapRouter.sol";
 import { IUniswapV3Quoter } from "./IUniswapV3Quoter.sol";
+import { IUniswapV3SwapRouter } from "./IUniswapV3SwapRouter.sol";
 
 library UniswapV3 {
     using Path for bytes;
@@ -69,7 +69,7 @@ library UniswapV3 {
 
     function encodePath(address[] memory _path, uint24[] memory _fees) internal pure returns (bytes memory) {
         bytes memory res;
-        for (uint256 i = 0; i < _fees.length; i++) {
+        for (uint256 i; i < _fees.length; i++) {
             res = abi.encodePacked(res, _path[i], _fees[i]);
         }
         res = abi.encodePacked(res, _path[_path.length - 1]);


### PR DESCRIPTION
- Specify the version of the openzeppelin dependency in the import path.
- Organize imports by sorting them in the following order: dependencies > contracts > tests.
- Remove variable initialization when the value is explicitly set to 0.

